### PR TITLE
Provide more flexible React peer dependency range

### DIFF
--- a/build/npm/package.json
+++ b/build/npm/package.json
@@ -26,6 +26,6 @@
     "scrolling  "
   ],
   "peerDependencies": {
-    "react": "0.12.x"
+    "react": ">=0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-loader": "^4.0.0",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",
-    "react": "^0.12.2",
+    "react": ">=0.12.0",
     "webpack": "^1.6.0",
     "webpack-dev-server": "^1.7.0"
   }


### PR DESCRIPTION
Allows for React v0.13.x while maintaining v0.12.x support. Tested on my machine on a few modern browsers and works well. 