### PR TITLE
Fix issue where top/height always 0

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -164,7 +164,7 @@ var Helpers = {
     componentDidMount: function() {
       if(this.props.spy) {
         var to = this.props.to;
-        var element = __mapped[to];
+        var element = null;
         var top = 0;
         var height = 0;
         var self = this;


### PR DESCRIPTION
* The top/height can sometimes always be 0, I believe due to the order
  in which the components are added to the page.
* Calculate top/height the first time the func is called