### PR TITLE
Fix scroll-spy events leaking after component unmount

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -5,7 +5,7 @@ var assign = require('react/lib/Object.assign');
 var Helpers = require('../mixins/Helpers');
 
 var Link = React.createClass({
-  mixins: [Helpers.Scroll, Helpers.Spy],
+  mixins: [Helpers.Scroll],
   getInitialState : function() {
   	return { active : false};
   },

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,3 +1,5 @@
 exports.Link = require('./components/Link.js');
 exports.Element = require('./components/Element.js');
 exports.Helpers = require('./mixins/Helpers.js');
+exports.scroller = require('./mixins/scroller.js');
+exports.scrollSpy = require('./mixins/scroll-spy.js');

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -1,149 +1,29 @@
 "use strict";
 
 var React = require('react');
-
-var smooth = require('./smooth');
-
-var easing = smooth.defaultEasing;
-
-var cancelEvents = require('./cancel-events');
-
-/*
- * Sets the cancel trigger
- */
-
-cancelEvents.register(function() {
-  __cancel = true;
-});
-
-/*
- * Spy helper
- */
-
- var spyCallbacks = [];
- var spySetState = [];
-
- document.addEventListener('scroll', function() {
-  for(var i = 0; i < spyCallbacks.length; i = i + 1) {
-    spyCallbacks[i](currentPositionY());
-  }
- });
-
-/*
- * Helper function to never extend 60fps on the webpage.
- */
-var requestAnimationFrame = (function () {
-  return  window.requestAnimationFrame       ||
-          window.webkitRequestAnimationFrame ||
-          function (callback, element, delay) {
-              window.setTimeout(callback, delay || (1000/60));
-          };
-})();
-
-var __activeLink;
-var __mapped            = {};
-var __currentPositionY  = 0;
-var __startPositionY    = 0;
-var __targetPositionY   = 0;
-var __progress          = 0;
-var __duration          = 0;
-var __cancel            = false;
-
-var __start;
-var __deltaTop;
-var __percent;
-
-var currentPositionY = function() {
-  var supportPageOffset = window.pageXOffset !== undefined;
-  var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
-  return  supportPageOffset ? window.pageYOffset : isCSS1Compat ?
-          document.documentElement.scrollTop : document.body.scrollTop;
-};
-
-var animateTopScroll = function(timestamp) {
-  // Cancel on specific events
-  if(__cancel) { return };
-
-
-  __deltaTop = Math.round(__targetPositionY - __startPositionY);
-
-  if (__start === null) {
-    __start = timestamp;
-  }
-
-  __progress = timestamp - __start;
-
-  __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
-
-  __currentPositionY = __startPositionY + Math.ceil(__deltaTop * __percent);
-
-  window.scrollTo(0, __currentPositionY);
-
-  if(__percent < 1) {
-    requestAnimationFrame(animateTopScroll);
-  }
-
-};
-
-var startAnimateTopScroll = function(y, options) {
-  __start           = null;
-  __cancel          = false;
-  __startPositionY  = currentPositionY();
-  __targetPositionY = y + __startPositionY;
-  __duration        = options.duration || 1000;
-
-  requestAnimationFrame(animateTopScroll);
-};
+var animateScroll = require('./animate-scroll');
+var scrollSpy = require('./scroll-spy');
+var scroller = require('./scroller');
 
 var Helpers = {
-  reset: function() {
-    __mapped = [];
-    spySetState = [];
-    spyCallbacks = [];
-  },
+
   Scroll: {
+
     propTypes: {
       to: React.PropTypes.string.isRequired,
       offset: React.PropTypes.number
     },
+
     getDefaultProps: function() {
       return {offset: 0};
     },
+
     scrollTo : function(to) {
-
-      /*
-       * get the mapped DOM element
-       */
-
-      var target = __mapped[to];
-
-      if(!target) {
-        throw new Error("target Element not found");
-      }
-
-      var cordinates = target.getBoundingClientRect();
-
-      /*
-       * if smooth is not provided just scroll into the view
-       */
-
-      if(!this.props.smooth) {
-        window.scrollTo(0, cordinates.top);
-        return;
-      }
-
-      /*
-       * Animate scrolling
-       */
-
-      var options = {
-        duration : this.props.duration
-      };
-
-      startAnimateTopScroll(cordinates.top + this.props.offset, options);
-
+      scroller.scrollTo(to, this.props.smooth, this.props.duration, this.props.offset);
     },
+
     onClick: function(event) {
+
       /*
        * give the posibility to override onClick
        */
@@ -174,53 +54,48 @@ var Helpers = {
         var height = 0;
         var self = this;
 
-        spySetState.push(function() {
-          if(__activeLink != to) {
-            self.setState({ active : false });
+        scrollSpy.addStateHandler(function() {
+          if(scroller.getActiveLink() != to) {
+              self.setState({ active : false });
           }
         });
 
-        spyCallbacks.push(function(y) {
+        scrollSpy.addSpyHandler(function(y) {
 
           if(!element) {
-            element = __mapped[to];
-            var cords = element.getBoundingClientRect();
-            top = (cords.top + y);
-            height = top + cords.height;
+              element = scroller.get(to);
+              var cords = element.getBoundingClientRect();
+              top = (cords.top + y);
+              height = top + cords.height;
           }
 
           var offsetY = y - self.props.offset;
 
-          if(offsetY >= top && offsetY <= height && __activeLink != to) {
+          if(offsetY >= top && offsetY <= height && scroller.getActiveLink() != to) {
 
-            __activeLink = to;
+            scroller.setActiveLink(to);
 
             self.setState({ active : true });
 
-            var length = spySetState.length;
-
-            for(var i = 0; i < length; i = i + 1) {
-              spySetState[i]();
-            }
-
+            scrollSpy.updateStates();
           }
         });
       }
     }
   },
+
   Element: {
     propTypes: {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      __mapped[this.props.name] = this.getDOMNode();
+      scroller.register(this.props.name, this.getDOMNode());
     },
     componentWillUnmount: function() {
-      delete __mapped[this.props.name];
+      scroller.unregister(this.props.name);
     }
   }
 };
 
 module.exports = Helpers;
-
 

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -96,6 +96,11 @@ var startAnimateTopScroll = function(y, options) {
 };
 
 var Helpers = {
+  reset: function() {
+    __mapped = [];
+    spySetState = [];
+    spyCallbacks = [];
+  },
   Scroll: {
     propTypes: {
       to: React.PropTypes.string.isRequired,

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -1,0 +1,84 @@
+var smooth = require('./smooth');
+
+var easing = smooth.defaultEasing;
+
+var cancelEvents = require('./cancel-events');
+
+/*
+ * Sets the cancel trigger
+ */
+
+cancelEvents.register(function() {
+  __cancel = true;
+});
+
+
+/*
+ * Helper function to never extend 60fps on the webpage.
+ */
+var requestAnimationFrame = (function () {
+  return  window.requestAnimationFrame       ||
+          window.webkitRequestAnimationFrame ||
+          function (callback, element, delay) {
+              window.setTimeout(callback, delay || (1000/60));
+          };
+})();
+
+
+var __currentPositionY  = 0;
+var __startPositionY    = 0;
+var __targetPositionY   = 0;
+var __progress          = 0;
+var __duration          = 0;
+var __cancel            = false;
+
+var __start;
+var __deltaTop;
+var __percent;
+
+var currentPositionY = function() {
+  var supportPageOffset = window.pageXOffset !== undefined;
+  var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+  return supportPageOffset ? window.pageYOffset : isCSS1Compat ?
+         document.documentElement.scrollTop : document.body.scrollTop;
+};
+
+var animateTopScroll = function(timestamp) {
+  // Cancel on specific events
+  if(__cancel) { return };
+
+
+  __deltaTop = Math.round(__targetPositionY - __startPositionY);
+
+  if (__start === null) {
+    __start = timestamp;
+  }
+
+  __progress = timestamp - __start;
+
+  __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
+
+  __currentPositionY = __startPositionY + Math.ceil(__deltaTop * __percent);
+
+  window.scrollTo(0, __currentPositionY);
+
+  if(__percent < 1) {
+    requestAnimationFrame(animateTopScroll);
+  }
+
+};
+
+var startAnimateTopScroll = function(y, options) {
+  __start           = null;
+  __cancel          = false;
+  __startPositionY  = currentPositionY();
+  __targetPositionY = y + __startPositionY;
+  __duration        = options.duration || 1000;
+
+  requestAnimationFrame(animateTopScroll);
+};
+
+module.exports = {
+  animateTopScroll: startAnimateTopScroll
+};
+

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,0 +1,40 @@
+var spyCallbacks = [];
+var spySetState = [];
+
+var currentPositionY = function() {
+  var supportPageOffset = window.pageXOffset !== undefined;
+  var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+  return supportPageOffset ? window.pageYOffset : isCSS1Compat ?
+          document.documentElement.scrollTop : document.body.scrollTop;
+};
+
+document.addEventListener('scroll', function() {
+  for(var i = 0; i < spyCallbacks.length; i = i + 1) {
+    spyCallbacks[i](currentPositionY());
+  }
+});
+
+module.exports = {
+  umount: function(){
+    spySetState = [];
+    spyCallbacks = [];
+  },
+
+  addStateHandler: function(handler){
+    spySetState.push(handler);
+  },
+
+  addSpyHandler: function(handler){
+    spyCallbacks.push(handler);
+  },
+
+  updateStates: function(){
+
+    var length = spySetState.length;
+
+    for(var i = 0; i < length; i = i + 1) {
+      spySetState[i]();
+    }
+
+  }
+};

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -15,7 +15,7 @@ document.addEventListener('scroll', function() {
 });
 
 module.exports = {
-  umount: function(){
+  unmount: function(){
     spySetState = [];
     spyCallbacks = [];
   },

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -48,7 +48,7 @@ module.exports = {
        */
 
       if(!animate) {
-        window.scrollTo(0, cordinates.top);
+        window.scrollTo(0, cordinates.top + (offset || 0));
         return;
       }
 

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -1,0 +1,67 @@
+var animateScroll = require('./animate-scroll');
+
+var __mapped = {};
+var __activeLink;
+
+module.exports = {
+
+  unmount: function() {
+    __mapped = [];
+  },
+
+  register: function(name, element){
+    __mapped[name] = element;
+  },
+
+  unregister: function(name) {
+    delete __mapped[name];
+  },
+
+  get: function(name) {
+    return __mapped[name];
+  },
+
+  setActiveLink: function(link) {
+    __activeLink = link;
+  },
+
+  getActiveLink: function() {
+    return __activeLink;
+  },
+
+  scrollTo: function(to, animate, duration, offset) {
+
+     /*
+     * get the mapped DOM element
+     */
+
+      var target = __mapped[to];
+
+      if(!target) {
+        throw new Error("target Element not found");
+      }
+
+      var cordinates = target.getBoundingClientRect();
+
+      /*
+       * if animate is not provided just scroll into the view
+       */
+
+      if(!animate) {
+        window.scrollTo(0, cordinates.top);
+        return;
+      }
+
+      /*
+       * Animate scrolling
+       */
+
+      var options = {
+        duration : duration
+      };
+
+      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options);
+
+  }
+};
+


### PR DESCRIPTION
* If scroll-spy is enabled and the component is unmounted the scroll
  events will still hang around and attempt to set state.
* The design should probably be changed to not use globals (a service
  instead perhaps?), though this is a quick fix.