### PR TITLE
unmount scrollSpy when unmounting

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -84,6 +84,10 @@ var Helpers = {
     }
   },
 
+  componentWillUnmount: function(){
+    scrollSpy.unmount();
+  },
+
   Element: {
     propTypes: {
       name: React.PropTypes.string.isRequired


### PR DESCRIPTION
Seems unmount() on the scrollSpy was never called? It gave errors in Safari when scrolling.