### PR TITLE
added scrollable div functionality

### DIFF
--- a/build/npm/lib/components/Element.js
+++ b/build/npm/lib/components/Element.js
@@ -10,7 +10,7 @@ var Element = React.createClass({
     /*
      * Not sure if should allow more then one property?
      */
-
+     // not if this is needed?
     var className = this.props.className || "";
     
     var props = assign({}, this.props, {

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -95,16 +95,12 @@ var Helpers = {
     componentDidMount: function() {
       //check if the parentId was added as a prop to element (optional)
       if (this.props.parentId){
-        //find relative position of element tag
-        //<Element id = "example"></Element>
-        var position = $('#' + this.props.id).position();
-        var relativePosition = position.top;
-      }
-      //get the query of the scrollable div that contains the element
-      var parentQuery = $(this.props.parentId);
-      
-      //pass in new paramaters: parentQuery and relativePosition
-      scroller.register(this.props.name, this.getDOMNode(), parentQuery, relativePosition);
+        //use react getDomNode and offsetTop to get relative position from top of parent div
+        var relativePosition = this.getDOMNode().offsetTop;
+        var parent = document.getElementById(this.props.parentId);
+      } 
+      //pass in new paramaters: parent and relativePosition
+      scroller.register(this.props.name, this.getDOMNode(), parent, relativePosition);
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -93,7 +93,13 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      scroller.register(this.props.name, this.getDOMNode());
+      if (this.props.relativeId){
+        var position = $(this.props.relativeId).position();
+        var relativePosition = position.top;
+      }
+      var parentQuery = $(this.props.parentId);
+      
+      scroller.register(this.props.name, this.getDOMNode(), parentQuery, relativePosition);
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -93,8 +93,8 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      //check if the id was added as a prop to element (optional)
-      if (this.props.id){
+      //check if the parentId was added as a prop to element (optional)
+      if (this.props.parentId){
         //find relative position of element tag
         //<Element id = "example"></Element>
         var position = $('#' + this.props.id).position();

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -93,12 +93,17 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
+      //check if the relativeId was added as a prop to element (optional)
       if (this.props.relativeId){
+        //find relative position of element tag
+        //<p id ="example"><Element relativeId = "#example"></Element></p>
         var position = $(this.props.relativeId).position();
         var relativePosition = position.top;
       }
+      //get the query of the scrollable div that contains the element
       var parentQuery = $(this.props.parentId);
       
+      //pass in new paramaters: parentQuery and relativePosition
       scroller.register(this.props.name, this.getDOMNode(), parentQuery, relativePosition);
     },
     componentWillUnmount: function() {

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -93,11 +93,11 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      //check if the relativeId was added as a prop to element (optional)
-      if (this.props.relativeId){
+      //check if the id was added as a prop to element (optional)
+      if (this.props.id){
         //find relative position of element tag
-        //<p id ="example"><Element relativeId = "#example"></Element></p>
-        var position = $(this.props.relativeId).position();
+        //<Element id = "example"></Element>
+        var position = $('#' + this.props.id).position();
         var relativePosition = position.top;
       }
       //get the query of the scrollable div that contains the element

--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -59,9 +59,8 @@ var animateTopScroll = function(timestamp) {
   // Cancel on specific events
   if(__cancel) { return; }
 
-  //added this part 
   if (__parentQuery){
-
+    //run animate on the parent div query and input __relativePosition for scrollTop and __duration for duration
     __parentQuery.animate({
       scrollTop: __relativePosition
     }, __duration);
@@ -95,10 +94,12 @@ var startAnimateTopScroll = function(y, options) {
   __startPositionY  = currentPositionY();
   __targetPositionY = y + __startPositionY;
   __duration        = options.duration || 1000;
+
   if (parentQuery){
     __parentQuery = parentQuery;
     __relativePosition = relativePosition;
   }
+
   requestAnimationFrame(animateTopScroll);
 };
 

--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -40,7 +40,7 @@ var __duration          = 0;
 var __cancel            = false;
 
 //added for div element /container
-var __parentQuery       = false;
+var __parent            = false;
 var __relativePosition  = false;
 
 
@@ -59,44 +59,48 @@ var animateTopScroll = function(timestamp) {
   // Cancel on specific events
   if(__cancel) { return; }
 
-  if (__parentQuery){
-    //run animate on the parent div query and input __relativePosition for scrollTop and __duration for duration
-    __parentQuery.animate({
-      scrollTop: __relativePosition
-    }, __duration);
+  if (__start === null) {
+      __start = timestamp;
+  }
 
+  __progress = timestamp - __start;
+
+  __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
+  
+  //added this part 
+  if (__parent){   
+    __deltaTop = __relativePosition;
+
+    __currentPositionY = Math.ceil(__deltaTop * __percent);
+
+    __parent.scrollTop = __currentPositionY;
+
+    
   }else {
     __deltaTop = Math.round(__targetPositionY - __startPositionY);
-    
-    if (__start === null) {
-      __start = timestamp;
-    }
-
-    __progress = timestamp - __start;
-
-    __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
 
     __currentPositionY = __startPositionY + Math.ceil(__deltaTop * __percent);
 
     window.scrollTo(0, __currentPositionY);
 
-    if(__percent < 1) {
-      requestAnimationFrame(animateTopScroll);
-    }
-
   }
+
+  if (__percent < 1){
+    requestAnimationFrame(animateTopScroll);   
+  }
+
 
 };
 
-var startAnimateTopScroll = function(y, options) {
+var startAnimateTopScroll = function(y, options, parent, relativePosition) {
   __start           = null;
   __cancel          = false;
   __startPositionY  = currentPositionY();
   __targetPositionY = y + __startPositionY;
   __duration        = options.duration || 1000;
 
-  if (parentQuery){
-    __parentQuery = parentQuery;
+  if (parent){
+    __parent = parent;
     __relativePosition = relativePosition;
   }
 

--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -39,6 +39,11 @@ var __progress          = 0;
 var __duration          = 0;
 var __cancel            = false;
 
+//added for div element /container
+var __parentQuery       = false;
+var __relativePosition  = false;
+
+
 var __start;
 var __deltaTop;
 var __percent;
@@ -52,25 +57,34 @@ var currentPositionY = function() {
 
 var animateTopScroll = function(timestamp) {
   // Cancel on specific events
-  if(__cancel) { return };
+  if(__cancel) { return; }
 
+  //added this part 
+  if (__parentQuery){
 
-  __deltaTop = Math.round(__targetPositionY - __startPositionY);
+    __parentQuery.animate({
+      scrollTop: __relativePosition
+    }, __duration);
 
-  if (__start === null) {
-    __start = timestamp;
-  }
+  }else {
+    __deltaTop = Math.round(__targetPositionY - __startPositionY);
+    
+    if (__start === null) {
+      __start = timestamp;
+    }
 
-  __progress = timestamp - __start;
+    __progress = timestamp - __start;
 
-  __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
+    __percent = (__progress >= __duration ? 1 : easing(__progress/__duration));
 
-  __currentPositionY = __startPositionY + Math.ceil(__deltaTop * __percent);
+    __currentPositionY = __startPositionY + Math.ceil(__deltaTop * __percent);
 
-  window.scrollTo(0, __currentPositionY);
+    window.scrollTo(0, __currentPositionY);
 
-  if(__percent < 1) {
-    requestAnimationFrame(animateTopScroll);
+    if(__percent < 1) {
+      requestAnimationFrame(animateTopScroll);
+    }
+
   }
 
 };
@@ -81,7 +95,10 @@ var startAnimateTopScroll = function(y, options) {
   __startPositionY  = currentPositionY();
   __targetPositionY = y + __startPositionY;
   __duration        = options.duration || 1000;
-
+  if (parentQuery){
+    __parentQuery = parentQuery;
+    __relativePosition = relativePosition;
+  }
   requestAnimationFrame(animateTopScroll);
 };
 

--- a/build/npm/lib/mixins/scroller.js
+++ b/build/npm/lib/mixins/scroller.js
@@ -9,10 +9,10 @@ module.exports = {
     __mapped = [];
   },
 
-  register: function(name, element){
+  register: function(name, element, parent, relativePosition){
     __mapped[name] = element;
-    //save the parentQuery to the object and the relativeposition of the element inside of the parent div
-    __mapped[name + "parent"] = parentQuery;
+    //save the parent to the object and the relativeposition of the element inside of the parent div
+    __mapped[name + "parent"] = parent;
     __mapped[name + "position"] = relativePosition;
   },
 
@@ -40,14 +40,13 @@ module.exports = {
      * get the mapped DOM element
      */
 
-      var parentQuery;
-      var relativePosition;
+
       //check to make sure that the scrollable parent div exists
-      if (__mapped[to+"parent"].length > 0){
-        relativePosition = __mapped[to + "position"];
-        parentQuery = __mapped[to + "parent"];
+      if (__mapped[to+"parent"]){
+        var relativePosition = __mapped[to + "position"];
+        var parent = __mapped[to + "parent"];
         //set the target equal to the Dom of the parent div
-        var target = parentQuery.get(0);
+        var target = parent;
       }
       else {
         var target = __mapped[to];
@@ -64,8 +63,8 @@ module.exports = {
 
       if(!animate) {
         //if parent div exists just set the scrolTop of the div to the relativePosition of the element (no animation or duration)
-        if (parentQuery){
-          parentQuery.get(0).scrollTop = relativePosition;
+        if (parent){
+          parent.scrollTop = relativePosition;
           return;
         }
         //if parent div doesn't exist run normally
@@ -82,7 +81,7 @@ module.exports = {
         duration : duration
       };
       //added parentQ parameter and relativePosition
-      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options, parentQuery, relativePosition);
+      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options, parent, relativePosition);
 
   }
 };

--- a/build/npm/lib/mixins/scroller.js
+++ b/build/npm/lib/mixins/scroller.js
@@ -11,7 +11,7 @@ module.exports = {
 
   register: function(name, element){
     __mapped[name] = element;
-    //added parent dom
+    //save the parentQuery to the object and the relativeposition of the element inside of the parent div
     __mapped[name + "parent"] = parentQuery;
     __mapped[name + "position"] = relativePosition;
   },
@@ -42,9 +42,11 @@ module.exports = {
 
       var parentQuery;
       var relativePosition;
+      //check to make sure that the scrollable parent div exists
       if (__mapped[to+"parent"].length > 0){
         relativePosition = __mapped[to + "position"];
         parentQuery = __mapped[to + "parent"];
+        //set the target equal to the Dom of the parent div
         var target = parentQuery.get(0);
       }
       else {
@@ -61,10 +63,12 @@ module.exports = {
        */
 
       if(!animate) {
+        //if parent div exists just set the scrolTop of the div to the relativePosition of the element (no animation or duration)
         if (parentQuery){
           parentQuery.get(0).scrollTop = relativePosition;
           return;
         }
+        //if parent div doesn't exist run normally
         window.scrollTo(0, cordinates.top + (offset || 0));
         return;
         
@@ -77,7 +81,7 @@ module.exports = {
       var options = {
         duration : duration
       };
-      //added parent parameter
+      //added parentQ parameter and relativePosition
       animateScroll.animateTopScroll(cordinates.top + (offset || 0), options, parentQuery, relativePosition);
 
   }

--- a/build/npm/lib/mixins/scroller.js
+++ b/build/npm/lib/mixins/scroller.js
@@ -11,10 +11,15 @@ module.exports = {
 
   register: function(name, element){
     __mapped[name] = element;
+    //added parent dom
+    __mapped[name + "parent"] = parentQuery;
+    __mapped[name + "position"] = relativePosition;
   },
 
   unregister: function(name) {
     delete __mapped[name];
+    delete __mapped[name + "parent"];
+    delete __mapped[name + "position"];
   },
 
   get: function(name) {
@@ -35,21 +40,34 @@ module.exports = {
      * get the mapped DOM element
      */
 
-      var target = __mapped[to];
+      var parentQuery;
+      var relativePosition;
+      if (__mapped[to+"parent"].length > 0){
+        relativePosition = __mapped[to + "position"];
+        parentQuery = __mapped[to + "parent"];
+        var target = parentQuery.get(0);
+      }
+      else {
+        var target = __mapped[to];
+      }
 
       if(!target) {
         throw new Error("target Element not found");
       }
 
       var cordinates = target.getBoundingClientRect();
-
       /*
        * if animate is not provided just scroll into the view
        */
 
       if(!animate) {
+        if (parentQuery){
+          parentQuery.get(0).scrollTop = relativePosition;
+          return;
+        }
         window.scrollTo(0, cordinates.top + (offset || 0));
         return;
+        
       }
 
       /*
@@ -59,8 +77,8 @@ module.exports = {
       var options = {
         duration : duration
       };
-
-      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options);
+      //added parent parameter
+      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options, parentQuery, relativePosition);
 
   }
 };


### PR DESCRIPTION
Hi!
So I tried to add the extra functionality to allow the option for react-scroll to work inside of a scrollable div. Original functionality is maintained (hopefully haha), and now users should be able to animate scrolling inside of a div as well as non animated scrolling. 
In order to test the format of using this extra functionality is:
div id = "scrollable"
      anytag id = "id"
           Element name="name" parentId="#scrollable" relativeId="#id" [Scroll to me!] /Element
     /anytag
/div

The extra props 'parentId' and 'relativeId' are the optional props and the 'anytag' is the Dom element that is used to find the relative position of the Element inside of the scrollable div. Link should work just the same. 
Any and all improvements, suggestions, and criticisms are welcome! (I know there are probably gonna be a ton of them haha).