### PR TITLE
Bugfix/fix for set state warnings

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -46,40 +46,38 @@ var Helpers = {
       this.scrollTo(this.props.to);
 
     },
+
     componentDidMount: function() {
       if(this.props.spy) {
         var to = this.props.to;
         var element = null;
         var top = 0;
         var height = 0;
-        var self = this;
 
-        scrollSpy.addStateHandler(function() {
+        scrollSpy.addStateHandler((function() {
           if(scroller.getActiveLink() != to) {
-              self.setState({ active : false });
+              this.setState({ active : false });
           }
-        });
+        }).bind(this));
 
-        scrollSpy.addSpyHandler(function(y) {
+        scrollSpy.addSpyHandler((function(y) {
 
           if(!element) {
               element = scroller.get(to);
+
               var cords = element.getBoundingClientRect();
               top = (cords.top + y);
               height = top + cords.height;
           }
 
-          var offsetY = y - self.props.offset;
+          var offsetY = y - this.props.offset;
 
           if(offsetY >= top && offsetY <= height && scroller.getActiveLink() != to) {
-
             scroller.setActiveLink(to);
-
-            self.setState({ active : true });
-
+            this.setState({ active : true });
             scrollSpy.updateStates();
           }
-        });
+        }).bind(this));
       }
     },
     componentWillUnmount: function() {

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -81,12 +81,12 @@ var Helpers = {
           }
         });
       }
+    },
+    componentWillUnmount: function() {
+      scrollSpy.unmount();
     }
   },
 
-  componentWillUnmount: function(){
-    scrollSpy.unmount();
-  },
 
   Element: {
     propTypes: {

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -8,16 +8,19 @@ var currentPositionY = function() {
           document.documentElement.scrollTop : document.body.scrollTop;
 };
 
+var scrollHandler = function() {
+  for(var i = 0; i < spyCallbacks.length; i = i + 1) {
+    spyCallbacks[i](currentPositionY());
+  }
+};
+
 if (typeof document !== 'undefined') {
-  document.addEventListener('scroll', function() {
-    for(var i = 0; i < spyCallbacks.length; i = i + 1) {
-      spyCallbacks[i](currentPositionY());
-    }
-  });
+  document.addEventListener('scroll', scrollHandler);
 }
 
 module.exports = {
   unmount: function(){
+    document.removeEventListener('scroll', scrollHandler);
     spySetState = [];
     spyCallbacks = [];
   },
@@ -37,6 +40,5 @@ module.exports = {
     for(var i = 0; i < length; i = i + 1) {
       spySetState[i]();
     }
-
   }
 };


### PR DESCRIPTION
This fixes issues where react-scroll would induce setState warnings in a react application with react-scroll  elements in different views that can be navigated between. E.g., if I'm using something like react-router and I'm switching between different views with react-scroll components, the application would throw setState warnings.