### PR TITLE
Fix for broken scroll-spy

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -48,6 +48,8 @@ var Helpers = {
     },
 
     componentDidMount: function() {
+      scrollSpy.mount();
+
       if(this.props.spy) {
         var to = this.props.to;
         var element = null;

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -16,7 +16,7 @@ var scrollSpy = {
   },
 
   scrollHandler: function () {
-    for(var i = 0; i < this.spyCallbacks.length; i = i + 1) {
+    for(var i = 0; i < this.spyCallbacks.length; i++) {
       this.spyCallbacks[i](this.currentPositionY());
     }
   },

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,44 +1,47 @@
-var spyCallbacks = [];
-var spySetState = [];
+var scrollSpy = {
+  
+  spyCallbacks: [],
+  spySetState: [],
 
-var currentPositionY = function() {
-  var supportPageOffset = window.pageXOffset !== undefined;
-  var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
-  return supportPageOffset ? window.pageYOffset : isCSS1Compat ?
-          document.documentElement.scrollTop : document.body.scrollTop;
-};
+  mount: function () {
+    if (typeof document !== 'undefined') {
+      document.addEventListener('scroll', this.scrollHandler.bind(this));
+    }
+  },
+  currentPositionY: function () {
+    var supportPageOffset = window.pageXOffset !== undefined;
+    var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+    return supportPageOffset ? window.pageYOffset : isCSS1Compat ?
+            document.documentElement.scrollTop : document.body.scrollTop;
+  },
 
-var scrollHandler = function() {
-  for(var i = 0; i < spyCallbacks.length; i = i + 1) {
-    spyCallbacks[i](currentPositionY());
-  }
-};
-
-if (typeof document !== 'undefined') {
-  document.addEventListener('scroll', scrollHandler);
-}
-
-module.exports = {
-  unmount: function(){
-    document.removeEventListener('scroll', scrollHandler);
-    spySetState = [];
-    spyCallbacks = [];
+  scrollHandler: function () {
+    for(var i = 0; i < this.spyCallbacks.length; i = i + 1) {
+      this.spyCallbacks[i](this.currentPositionY());
+    }
   },
 
   addStateHandler: function(handler){
-    spySetState.push(handler);
+    this.spySetState.push(handler);
   },
 
   addSpyHandler: function(handler){
-    spyCallbacks.push(handler);
+    this.spyCallbacks.push(handler);
   },
 
   updateStates: function(){
+    var length = this.spySetState.length;
 
-    var length = spySetState.length;
-
-    for(var i = 0; i < length; i = i + 1) {
-      spySetState[i]();
+    for(var i = 0; i < length; i++) {
+      this.spySetState[i]();
     }
+  },
+  unmount: function () { 
+    this.spyCallbacks = [];
+    this.spySetState = [];
+
+    document.removeEventListener('scroll', this.scrollHandler);
   }
-};
+}
+
+module.exports = scrollSpy;

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -41,14 +41,16 @@ module.exports = {
         throw new Error("target Element not found");
       }
 
-      var cordinates = target.getBoundingClientRect();
+      var coordinates = target.getBoundingClientRect();
 
       /*
        * if animate is not provided just scroll into the view
        */
 
       if(!animate) {
-        window.scrollTo(0, cordinates.top + (offset || 0));
+        var bodyRect = document.body.getBoundingClientRect();
+        var scrollOffset = coordinates.top - bodyRect.top;
+        window.scrollTo(0, scrollOffset + (offset || 0));
         return;
       }
 
@@ -60,7 +62,7 @@ module.exports = {
         duration : duration
       };
 
-      animateScroll.animateTopScroll(cordinates.top + (offset || 0), options);
+      animateScroll.animateTopScroll(coordinates.top + (offset || 0), options);
 
   }
 };


### PR DESCRIPTION
It seems I broke the scroll-spy functionality somewhat with my previous pull-request... This should fix that. Now, active-state should work when mounting/unmounting between instances.