### PR TITLE
Replaced deprecated React#getDOMNode

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -93,7 +93,7 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      scroller.register(this.props.name, this.getDOMNode());
+      scroller.register(this.props.name, React.findDOMNode(this));
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);


### PR DESCRIPTION
Replaced deprecated React#getDOMNode with React.findDOMNode which caused an error
``Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined``

Error occurs when using React via ES6 class syntax.

Related note from [React documentation](https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html)
> Added new top-level API React.findDOMNode(component), which should be used in place of component.getDOMNode(). The base class for ES6-based components will not have getDOMNode. This change will enable some more patterns moving forward.