### PR TITLE
add optional callback onSetActive, called when active Scroll Link is set

### DIFF
--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -78,6 +78,7 @@ var Helpers = {
           if(offsetY >= top && offsetY <= height && scroller.getActiveLink() != to) {
             scroller.setActiveLink(to);
             this.setState({ active : true });
+            if(this.props.onSetActive) this.props.onSetActive(to);
             scrollSpy.updateStates();
           }
         }).bind(this));

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -78,6 +78,7 @@ var Helpers = {
           if(offsetY >= top && offsetY <= height && scroller.getActiveLink() != to) {
             scroller.setActiveLink(to);
             this.setState({ active : true });
+            if(this.props.onSetActive) this.props.onSetActive(to);
             scrollSpy.updateStates();
           }
         }).bind(this));


### PR DESCRIPTION
Hi fisshy - thanks for the library! It's quite useful.

Currently, when you scroll to a Scroll Element, the corresponding Scroll Link <A> tag is given the class "active". However, I've run into a couple scenarios now where, due to my CSS/HTML structure, the *parent* element of the link (usually a LI tag) needs to get the "active" class, not the link itself. In particular, the nav in Bootstrap expects the LI, not the A, to be "active" in order to render correctly.

So I've added a simple hook which allows you to define an `onSetActive` callback on Scroll Link components. This way, when the link becomes active, I can respond to it in the parent component and add the "active" class to the proper parent. I'm sure it has other uses too.

Hope it's helpful! Thanks,
-d