### PR TITLE
update helper to use getDOMNode if available to be compatible with earlier React versions

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -104,7 +104,8 @@ var Helpers = {
       name: React.PropTypes.string.isRequired
     },
     componentDidMount: function() {
-      scroller.register(this.props.name, ReactDOM.findDOMNode(this));
+      var domNode = this.getDOMNode ? this.getDOMNode() : ReactDOM.findDOMNode(this);
+      scroller.register(this.props.name, domNode);
     },
     componentWillUnmount: function() {
       scroller.unregister(this.props.name);


### PR DESCRIPTION
I'm working on a project now that uses React 0.13.3, and it's having trouble with the findDOMNode function. I've found that this change fixes my issues, though I'm not sure if it'll make react-scroll scream deprecation warnings once 0.14 releases.

I suspect this may fix what's behind this issue as well: https://github.com/fisshy/react-scroll/issues/27