### PR TITLE
Add timestamp to requestAnimationFrame fallback

### DIFF
--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -27,7 +27,7 @@ var currentWindowProperties = function() {
 var requestAnimationFrame = (function () {
   return  currentWindowProperties() ||
           function (callback, element, delay) {
-              window.setTimeout(callback, delay || (1000/60));
+              window.setTimeout(callback, delay || (1000/60), new Date().getTime());
           };
 })();
 

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -27,7 +27,7 @@ var currentWindowProperties = function() {
 var requestAnimationFrame = (function () {
   return  currentWindowProperties() ||
           function (callback, element, delay) {
-              window.setTimeout(callback, delay || (1000/60));
+              window.setTimeout(callback, delay || (1000/60), new Date().getTime());
           };
 })();
 


### PR DESCRIPTION
animateScroll() assumes that there's a timestamp, so the requestAnimationFrame setTimeout fallback needs to add that. This enables scrolling in IE9.