### PR TITLE
ScrollSnapMixin: an extension to achieve scroll-snap emulation with react-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Checkout examples
 >> [Live](http://fisshy.github.io/react-scroll-example/basic/index.html)
 >> Or
 >> [Code](https://github.com/fisshy/react-scroll/blob/master/examples/basic/app.js)
+
 > Scroll-snap
 >> [Live](#)
 >> Or
 >> [Code](https://github.com/fisshy/react-scroll/blob/master/examples/scroll-snap/app.js)
+
 ### Usage
 ```js
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Checkout examples
 >> [Live](http://fisshy.github.io/react-scroll-example/basic/index.html)
 >> Or
 >> [Code](https://github.com/fisshy/react-scroll/blob/master/examples/basic/app.js)
-
+> Scroll-snap
+>> [Live](#)
+>> Or
+>> [Code](https://github.com/fisshy/react-scroll/blob/master/examples/scroll-snap/app.js)
 ### Usage
 ```js
 
@@ -86,7 +89,15 @@ var Link = React.createClass({
 
 ```
 
-
+### Scroll-snap emulation
+Mixin added an emulation of [scroll-snap](https://developer.mozilla
+.org/en-US/docs/Web/CSS/scroll-snap-type) to your components. This can 
+be interesting for landing pages. Just include the mixin into parent component.
+```
+...
+  mixins: [ScrollSnapMixin],
+...  
+```
 
 ### Todo
 - [x] Vertical scrolling

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<header>
+<head>
 	<title>React Scroll Examples</title>
 	<link href="app.css" rel="stylesheet"/>
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css"
-</header>
+</head>
 <body>
 	<div id="example">
 	</div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,1 +1,2 @@
-<a href="/basic/index.html"> Basic </a>
+<a href="/basic/index.html"> Basic </a><br/>
+<a href="/scroll-snap/index.html"> ScrollSnap </a>

--- a/examples/scroll-snap/app.css
+++ b/examples/scroll-snap/app.css
@@ -1,0 +1,11 @@
+.element {
+	height:100vh;
+	font-size: 45px;
+	border-top:1px solid #000;
+	padding-top:55px;
+	padding-left:10px;
+}
+
+.active {
+	color:red !important;
+}

--- a/examples/scroll-snap/app.css
+++ b/examples/scroll-snap/app.css
@@ -1,9 +1,24 @@
+/* uncomment this if native scroll-snap is needed */
+/*@supports (scroll-snap-type: mandatory) or (-webkit-scroll-snap-type: mandatory) {
+	#wrapper {
+		height: 100vh;
+	}
+}*/
+
+#wrapper {
+	overflow-y: auto;
+	scroll-behavior: smooth;
+	scroll-snap-type: mandatory;
+	scroll-snap-points-y: repeat(100vh);
+}
+
 .element {
 	height:100vh;
 	font-size: 45px;
 	border-top:1px solid #000;
 	padding-top:55px;
 	padding-left:10px;
+	/*scroll-snap-coordinate: 0 0;*/
 }
 
 .active {

--- a/examples/scroll-snap/app.js
+++ b/examples/scroll-snap/app.js
@@ -37,7 +37,7 @@ var Section = React.createClass({
     }
 
     return (
-      <div>
+      <div id="wrapper">
         <nav className="navbar navbar-default navbar-fixed-top">
           <div className="container-fluid">
             <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/examples/scroll-snap/app.js
+++ b/examples/scroll-snap/app.js
@@ -1,0 +1,84 @@
+"use strict";
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var Scroll = require('react-scroll'); 
+
+var Link = Scroll.Link;
+var Element = Scroll.Element;
+var ScrollSnapMixin = Scroll.ScrollSnapMixin;
+
+var Section = React.createClass({
+  getInitialState() {
+    return {
+      overflow: true
+    }
+  },
+
+  mixins: [ScrollSnapMixin],
+
+  handleClick: function () {
+    if (this.state.overflow) {
+      document.body.style.overflowY = 'hidden';
+      this.setState({ overflow: false });
+    } else {
+      document.body.style.overflowY = 'scroll';
+      this.setState({ overflow: true });
+    }
+  },
+
+  render: function () {
+    var overflow;
+
+    if (this.state.overflow) {
+      overflow = 'With';
+    } else {
+      overflow = 'Without';
+    }
+
+    return (
+      <div>
+        <nav className="navbar navbar-default navbar-fixed-top">
+          <div className="container-fluid">
+            <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+              <ul className="nav navbar-nav">
+                <li><Link to="test1" spy={true} smooth={true} duration={500} >Test 1</Link></li>
+                <li><Link to="test2" spy={true} smooth={true} duration={500}>Test 2</Link></li>
+                <li><Link to="test3" spy={true} smooth={true} duration={500} >Test 3</Link></li>
+                <li><Link to="test4" spy={true} smooth={true} duration={500}>Test 4</Link></li>
+                <li><Link to="test5" spy={true} smooth={true} duration={500}>Test 5</Link></li>
+                <li><a onClick={ this.handleClick }>{overflow} "overflow: hidden"</a></li>
+              </ul>
+            </div>
+          </div>
+        </nav>
+
+        <Element name="test1" className="element" style={{ backgroundColor: '#ffffff' }}>
+          test 1
+        </Element>
+
+        <Element name="test2" className="element" style={{ backgroundColor: '#008000' }}>
+          test 2
+        </Element>
+
+        <Element name="test3" className="element" style={{ backgroundColor: '#00C0C0' }}>
+          test 3
+        </Element>
+
+        <Element name="test4" className="element" style={{ backgroundColor: '#C0C0FF' }}>
+          test 4
+        </Element>
+
+        <Element name="test5" className="element" style={{ backgroundColor: '#FFC0FF' }}>
+          test 5
+        </Element>
+      </div>
+    );
+  }
+});
+
+
+ReactDOM.render(
+  <Section />,
+  document.getElementById('example')
+);

--- a/examples/scroll-snap/index.html
+++ b/examples/scroll-snap/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<head>
+	<title>React Scroll Examples</title>
+	<link href="app.css" rel="stylesheet"/>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css"
+</head>
+<body>
+	<div id="example">
+	</div>
+</body>
+
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/scroll-snap.js"></script>

--- a/modules/index.js
+++ b/modules/index.js
@@ -3,4 +3,5 @@ exports.Button = require('./components/Button.js');
 exports.Element = require('./components/Element.js');
 exports.Helpers = require('./mixins/Helpers.js');
 exports.scroller = require('./mixins/scroller.js');
+exports.ScrollSnapMixin = require('./mixins/scroll-snap.js');
 exports.scrollSpy = require('./mixins/scroll-spy.js');

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -20,7 +20,11 @@ var Helpers = {
     },
 
     scrollTo : function(to) {
+      var duration = this.props.duration;
+
       scroller.scrollTo(to, this.props.smooth, this.props.duration, this.props.offset);
+
+      setTimeout(function() { scroller.flushTarget() }, duration);
     },
 
     onClick: function(event) {
@@ -45,7 +49,6 @@ var Helpers = {
        */
 
       this.scrollTo(this.props.to);
-
     },
 
     componentDidMount: function() {

--- a/modules/mixins/scroll-snap.js
+++ b/modules/mixins/scroll-snap.js
@@ -44,6 +44,13 @@ var ScrollSnapMixin = {
 	},
 
 	componentWillMount() {
+		/* uncomment this if native scroll-snap is needed (in example css-file
+		 too) */
+
+		//var isScrollSnapSupported = 'scrollSnapType' in document.documentElement.style ||
+		//	'webkitScrollSnapType' in document.documentElement.style;
+		//if (isScrollSnapSupported) return;
+
 		// use capture phase here
 		if (typeof document !== 'undefined') {
 			document.addEventListener('wheel', this.wheelHandler, true);
@@ -107,7 +114,6 @@ var ScrollSnapMixin = {
 			return
 		}
 
-		// todo добавить проверку на поддержку нативного scroll snap
 		cancelEvent(e);
 
 		var direction = this.getWheelDirection(e);
@@ -135,7 +141,7 @@ var ScrollSnapMixin = {
 		var self = this;
 
 		setTimeout(function() {
-			self.setState({ scrolling: false, scrollY: window.pageYOffset })
+			self.setState({ scrolling: false, scrollY: scrollSpy.currentPositionY() })
 		}, self.props.duration + 30); // interval must be bigger than animation
 		// duration for preventing bug with trigger infinity loop
 	},
@@ -151,14 +157,11 @@ var ScrollSnapMixin = {
 
 		for (var e in elements) {
 			if( elements.hasOwnProperty(e) ) {
-				//elementsCoordinates[e] = elements[e].getBoundingClientRect()
 				var rectObject = elements[e].getBoundingClientRect();
 				rectObject.name = e;
 				elementsCoordinates.push(rectObject);
 			}
 		}
-
-		//var nearestElements = this.getMax(elementsCoordinates);
 
 		return this.getMax(elementsCoordinates);
 	},
@@ -200,7 +203,7 @@ var ScrollSnapMixin = {
 	},
 
 	/**
-	 *
+	 * Wheel direction detect here
 	 *
 	 * @param e is an event object
 	 * @returns {number} 1 - go up; -1 - go down
@@ -214,7 +217,7 @@ var ScrollSnapMixin = {
 	},
 
 	getScrollDirection: function(e) {
-		var currentPositionY = window.pageYOffset;
+		var currentPositionY = scrollSpy.currentPositionY();
 
 		/*if (e.type === 'touchend') {
 			currentPositionY = e.touches[0].clientY;

--- a/modules/mixins/scroll-snap.js
+++ b/modules/mixins/scroll-snap.js
@@ -1,0 +1,243 @@
+/**
+ *
+ */
+
+"use strict";
+
+var React = require('react');
+var animateScroll = require('./animate-scroll');
+var scroller = require('./scroller');
+var scrollSpy = require('./scroll-spy');
+
+var cancelEvent = function (e) {
+	//e.stopPropagation();
+	e.stopImmediatePropagation();
+	if (e.preventDefault) {
+		e.preventDefault();
+	} else {
+		e.returnValue = false;
+	}
+};
+
+var ScrollSnapMixin = {
+	propTypes: {
+		duration: React.PropTypes.number.isRequired,
+		offset: React.PropTypes.number,
+		smooth: React.PropTypes.bool
+	},
+
+	getInitialState() {
+		return {
+			scrolling: false,
+			scrollY: 0
+		}
+	},
+
+	getDefaultProps: function () {
+		return {
+			duration: 500,
+			offset: 0,
+			smooth: true
+
+		};
+	},
+
+	componentWillMount() {
+		// use capture phase here
+		if (typeof document !== 'undefined') {
+			document.addEventListener('wheel', this.wheelHandler, true);
+			document.addEventListener('scroll', this.scrollHandler, true);
+			document.addEventListener('keydown', this.keydownHandler, true);
+			//document.addEventListener('touchend', this.scrollHandler, true);
+		}
+	},
+
+	componentDidMount() {
+		this.setState({ scrollY: scrollSpy.currentPositionY() });
+	},
+
+	componentWillUnmount() {
+		//window.removeEventListener('resize', this.handleResize);
+		if (typeof document !== 'undefined') {
+			document.removeEventListener('wheel', this.wheelHandler);
+			document.removeEventListener('scroll', this.scrollHandler);
+			document.removeEventListener('keydown', this.keydownHandler);
+			//document.removeEventListener('touchend', this.scrollHandler);
+		}
+	},
+
+	keydownHandler: function(e) {
+		var direction = this.getKeydownDirection(e);
+
+		this.scrollToDirection(e, direction);
+	},
+
+	scrollHandler: function(e) {
+		if (this.state.scrolling) {
+			return
+		}
+		cancelEvent(e);
+
+		var direction = this.getScrollDirection(e);
+
+		if (!direction) {
+			return
+		}
+
+		this.scrollToDirection(e, direction);
+	},
+
+	wheelHandler: function(e) {
+		// todo если зажата кнопка, типа ctrl, то нужно игнорировать этот ивент
+
+		// todo добавить проверку на поддержку нативного scroll snap
+		cancelEvent(e);
+
+		var direction = this.getWheelDirection(e);
+
+		this.scrollToDirection(e, direction);
+	},
+
+	scrollToDirection: function(e, direction) {
+		if (this.state.scrolling) {
+			return
+		}
+
+		this.setState({ scrolling: true });
+
+		// We need to get current element
+		var nearestElements = this.getCurrentWithSiblings();
+
+		if (direction === 1 && nearestElements[2] !== null) {
+			this.scrollTo(nearestElements[2].name);
+		} else if (direction === -1 && nearestElements[0] !== null) {
+			this.scrollTo(nearestElements[0].name);
+		}
+
+		// it is needed to prevent multiple event handling till animation not finished
+		var self = this;
+
+		setTimeout(function() {
+			self.setState({ scrolling: false, scrollY: window.pageYOffset })
+		}, self.props.duration + 30); // interval must be bigger than animation
+		// duration for preventing bug with trigger infinity loop
+	},
+
+	/**
+	 * Function determines the elements nearest to visible one
+	 *
+	 * @returns string with element name
+	 */
+	getCurrentWithSiblings: function() {
+		var elements = scroller.getAll();
+		var elementsCoordinates = [];
+
+		for (var e in elements) {
+			if( elements.hasOwnProperty(e) ) {
+				//elementsCoordinates[e] = elements[e].getBoundingClientRect()
+				var rectObject = elements[e].getBoundingClientRect();
+				rectObject.name = e;
+				elementsCoordinates.push(rectObject);
+			}
+		}
+
+		//var nearestElements = this.getMax(elementsCoordinates);
+
+		return this.getMax(elementsCoordinates);
+	},
+
+	/**
+	 * Function returns an array of three elements: visible, upper and lower
+	 *
+	 * @param elements is an array of all sections
+	 * @returns [] with three elements
+	 */
+	getMax: function(elements) {
+		var max = -Infinity;
+		var upperElement, maxElement, lowerElement;
+
+		for (var i = 0; i < elements.length; i++) {
+		//for(var e in elements) {
+			if (elements[i].top > max && elements[i].top <= 0) {
+				max = elements[i].top;
+
+				if (elements[i].top !== 0) {
+					// for those cases when the upper part of the visible element does
+					// not fit on the viewport
+					upperElement = elements[i];
+				} else {
+					// previous element become upper if exists
+					upperElement = maxElement || null;
+				}
+				maxElement = elements[i];
+
+				if (typeof elements[i+1] === 'undefined') {
+					lowerElement = null
+				} else {
+					lowerElement = elements[i+1]
+				}
+			}
+		}
+
+		return [upperElement, maxElement, lowerElement];
+	},
+
+	/**
+	 *
+	 *
+	 * @param e is an event object
+	 * @returns {number} 1 - go up; -1 - go down
+	 */
+	getWheelDirection: function(e) {
+		if (e.deltaY > 0) {
+			return 1
+		}
+
+		return -1
+	},
+
+	getScrollDirection: function(e) {
+		var currentPositionY = window.pageYOffset;
+
+		/*if (e.type === 'touchend') {
+			currentPositionY = e.touches[0].clientY;
+		} else {
+			currentPositionY = window.pageYOffset;
+		}*/
+
+		var scrolledY = this.state.scrollY - currentPositionY;
+
+		if (scrolledY > 0) {
+			return -1
+		} else if (scrolledY < 0) {
+			return 1
+		}
+
+		return false;
+	},
+
+	getKeydownDirection: function (e) {
+		if (e.which === 40 || e.which === 34) {
+			e.stopPropagation();
+			e.preventDefault();
+
+			return 1;
+		} else if (e.which === 38 || e.which === 33) {
+			e.stopPropagation();
+			e.preventDefault();
+
+			return -1;
+		} else {
+			return false;
+		}
+	},
+
+	scrollTo : function(to) {
+		if (scroller.getTarget() === null) {
+			scroller.scrollTo(to, this.props.smooth, this.props.duration, this.props.offset);
+			scroller.flushTarget();
+		}
+	}
+};
+
+module.exports = ScrollSnapMixin;

--- a/modules/mixins/scroll-snap.js
+++ b/modules/mixins/scroll-snap.js
@@ -1,5 +1,5 @@
 /**
- *
+ * ScrollSpanMixin
  */
 
 "use strict";
@@ -28,6 +28,7 @@ var ScrollSnapMixin = {
 
 	getInitialState() {
 		return {
+			locked: false,
 			scrolling: false,
 			scrollY: 0
 		}
@@ -48,6 +49,9 @@ var ScrollSnapMixin = {
 			document.addEventListener('wheel', this.wheelHandler, true);
 			document.addEventListener('scroll', this.scrollHandler, true);
 			document.addEventListener('keydown', this.keydownHandler, true);
+			// we need to listen 'keyup' allow using combination like ctrl +
+			// mousewheelup, etc
+			document.addEventListener('keyup', this.keyupHandler, true);
 			//document.addEventListener('touchend', this.scrollHandler, true);
 		}
 	},
@@ -62,16 +66,27 @@ var ScrollSnapMixin = {
 			document.removeEventListener('wheel', this.wheelHandler);
 			document.removeEventListener('scroll', this.scrollHandler);
 			document.removeEventListener('keydown', this.keydownHandler);
+			document.addEventListener('keyup', this.keyupHandler);
 			//document.removeEventListener('touchend', this.scrollHandler);
 		}
 	},
 
 	keydownHandler: function(e) {
+		// if shift, ctrl or alt was pressed we should lock the scroll listeners
+		if (e.which === 16 || e.which === 17 || e.which === 18) {
+			this.setState({ locked: true });
+		}
+
 		var direction = this.getKeydownDirection(e);
 
 		this.scrollToDirection(e, direction);
 	},
 
+	keyupHandler: function(e) {
+		if (e.which === 16 || e.which === 17 || e.which === 18) {
+			this.setState({ locked: false });
+		}
+	},
 	scrollHandler: function(e) {
 		if (this.state.scrolling) {
 			return
@@ -88,7 +103,9 @@ var ScrollSnapMixin = {
 	},
 
 	wheelHandler: function(e) {
-		// todo если зажата кнопка, типа ctrl, то нужно игнорировать этот ивент
+		if (this.state.locked) {
+			return
+		}
 
 		// todo добавить проверку на поддержку нативного scroll snap
 		cancelEvent(e);

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -3,6 +3,10 @@ var animateScroll = require('./animate-scroll');
 var __mapped = {};
 var __activeLink;
 
+// This is needed to prevent scroll-snap from overriding 'to', when we need to
+// leap over several elements
+var __target = null;
+
 module.exports = {
 
   unmount: function() {
@@ -21,12 +25,28 @@ module.exports = {
     return __mapped[name];
   },
 
+  getAll: function() {
+    return __mapped;
+  },
+
   setActiveLink: function(link) {
     __activeLink = link;
   },
 
   getActiveLink: function() {
     return __activeLink;
+  },
+
+  setTarget: function(target) {
+    __target = target;
+  },
+
+  getTarget: function() {
+    return __target;
+  },
+
+  flushTarget: function() {
+    __target = null;
   },
 
   scrollTo: function(to, animate, duration, offset) {
@@ -40,6 +60,8 @@ module.exports = {
       if(!target) {
         throw new Error("target Element not found");
       }
+
+      this.setTarget(to);
 
       var coordinates = target.getBoundingClientRect();
 


### PR DESCRIPTION
Hello @fisshy,

please, take a look at this PR which brings new functionality to react-scroll. As said in title, my goal is to bring scroll-snap emulation to react-component to get the similar behavior like [here](blog.gospodarets.com/demos/scroll-snap-full-screen/) or [here (worked on wide screens only)](http://adn.agency/).

If you like it, please check it twice, because I'm just learning to programming;) Also, there is still some bugs, for example with touch events.