### PR TITLE
Viewport resize

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -60,6 +60,7 @@ var Helpers = {
 
       spyHandler: function(y) {
         var element = scroller.get(this.props.to);
+        if (!element) return;
         var cords = element.getBoundingClientRect();
         var topBound = cords.top + y;
         var bottomBound = topBound + cords.height;

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -52,58 +52,53 @@ var Helpers = {
 
       },
 
-      componentDidMount: function() {
-
-        scrollSpy.mount();
-
-        if(this.props.spy) {
-          var to = this.props.to;
-          var element = null;
-          var elemTopBound = 0;
-          var elemBottomBound = 0;
-
-          scrollSpy.addStateHandler((function() {
-            if(scroller.getActiveLink() != to) {
-                this.setState({ active : false });
-            }
-          }).bind(this));
-
-          scrollSpy.addSpyHandler((function(y) {
-
-            if(!element) {
-                element = scroller.get(to);
-
-                var cords = element.getBoundingClientRect();
-                elemTopBound = (cords.top + y);
-                elemBottomBound = elemTopBound + cords.height;
-            }
-
-            var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
-            var activeLink = scroller.getActiveLink();
-
-            if (isOutside && activeLink === to) {
-              scroller.setActiveLink(void 0);
-              this.setState({ active : false });
-
-            } else if (isInside && activeLink != to) {
-              scroller.setActiveLink(to);
-              this.setState({ active : true });
-
-              if(this.props.onSetActive) {
-                this.props.onSetActive(to);
-              }
-
-              scrollSpy.updateStates();
-
-            }
-          }).bind(this));
+      stateHandler: function() {
+        if(scroller.getActiveLink() != this.props.to) {
+            this.setState({ active : false });
         }
       },
-      componentWillUnmount: function() {
-        scrollSpy.unmount();
+
+      spyHandler: function(y) {
+        if(typeof this._topBound === 'undefined') {
+          var element = scroller.get(this.props.to);
+          var cords = element.getBoundingClientRect();
+          this._topBound = cords.top + y;
+          this._bottomBound = this._topBound + cords.height;
+        }
+        var topBound = this._topBound;
+        var bottomBound = this._bottomBound;
+        var offsetY = y - this.props.offset;
+        var to = this.props.to;
+        var isInside = (offsetY >= topBound && offsetY <= bottomBound);
+        var isOutside = (offsetY < topBound || offsetY > bottomBound);
+        var activeLink = scroller.getActiveLink();
+
+        if (isOutside && activeLink === to) {
+          scroller.setActiveLink(void 0);
+          this.setState({ active : false });
+
+        } else if (isInside && activeLink != to) {
+          scroller.setActiveLink(to);
+          this.setState({ active : true });
+
+          if(this.props.onSetActive) {
+            this.props.onSetActive(to);
+          }
+
+          scrollSpy.updateStates();
+        }
       },
+
+      componentDidMount: function() {
+        if (this.props.spy) {
+          scrollSpy.mount(this.stateHandler, this.spyHandler);
+        }
+      },
+
+      componentWillUnmount: function() {
+        scrollSpy.unmount(this.stateHandler, this.spyHandler);
+      },
+
       render: function() {
         var className = "";
         if(this.state && this.state.active) {
@@ -131,6 +126,7 @@ var Helpers = {
       propTypes: {
         name: React.PropTypes.string.isRequired
       },
+
       componentDidMount: function() {
         var domNode = ReactDOM.findDOMNode(this);
         scroller.register(this.props.name, domNode);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -59,14 +59,10 @@ var Helpers = {
       },
 
       spyHandler: function(y) {
-        if(typeof this._topBound === 'undefined') {
-          var element = scroller.get(this.props.to);
-          var cords = element.getBoundingClientRect();
-          this._topBound = cords.top + y;
-          this._bottomBound = this._topBound + cords.height;
-        }
-        var topBound = this._topBound;
-        var bottomBound = this._bottomBound;
+        var element = scroller.get(this.props.to);
+        var cords = element.getBoundingClientRect();
+        var topBound = cords.top + y;
+        var bottomBound = topBound + cords.height;
         var offsetY = y - this.props.offset;
         var to = this.props.to;
         var isInside = (offsetY >= topBound && offsetY <= bottomBound);

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -39,7 +39,7 @@ var scrollSpy = {
     var queue = this[queueKey] || [];
     var i = queue.indexOf(handler);
     if (i !== -1) {
-      this[queueKey] = queue.splice(i, 1);
+      queue.splice(i, 1);
     }
     if (document && !this.hasHandlers()) {
       document.removeEventListener('scroll', this._scrollHandler);


### PR DESCRIPTION
Branched from fisshy/react-scroll#58
Fixes fisshy/react-scroll#49

Caching `<Element>` bounding boxes causes functionality to break when the viewport is resized. It's faster to cache, [but maybe not _that_ much faster](https://jsperf.com/getboundingclientrect-cached). Seems reasonable to give the browser the responsibility of bbox caching until it proves to be too slow. This also somewhat aligns with Reacts official recommendation of computing the latest values on the fly (in `render` methods)