### PR TITLE
Initial active link

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -52,58 +52,53 @@ var Helpers = {
 
       },
 
-      componentDidMount: function() {
-
-        scrollSpy.mount();
-
-        if(this.props.spy) {
-          var to = this.props.to;
-          var element = null;
-          var elemTopBound = 0;
-          var elemBottomBound = 0;
-
-          scrollSpy.addStateHandler((function() {
-            if(scroller.getActiveLink() != to) {
-                this.setState({ active : false });
-            }
-          }).bind(this));
-
-          scrollSpy.addSpyHandler((function(y) {
-
-            if(!element) {
-                element = scroller.get(to);
-
-                var cords = element.getBoundingClientRect();
-                elemTopBound = (cords.top + y);
-                elemBottomBound = elemTopBound + cords.height;
-            }
-
-            var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
-            var activeLink = scroller.getActiveLink();
-
-            if (isOutside && activeLink === to) {
-              scroller.setActiveLink(void 0);
-              this.setState({ active : false });
-
-            } else if (isInside && activeLink != to) {
-              scroller.setActiveLink(to);
-              this.setState({ active : true });
-
-              if(this.props.onSetActive) {
-                this.props.onSetActive(to);
-              }
-
-              scrollSpy.updateStates();
-
-            }
-          }).bind(this));
+      stateHandler: function() {
+        if(scroller.getActiveLink() != this.props.to) {
+            this.setState({ active : false });
         }
       },
-      componentWillUnmount: function() {
-        scrollSpy.unmount();
+
+      spyHandler: function(y) {
+        if(typeof this._topBound === 'undefined') {
+          var element = scroller.get(this.props.to);
+          var cords = element.getBoundingClientRect();
+          this._topBound = cords.top + y;
+          this._bottomBound = this._topBound + cords.height;
+        }
+        var topBound = this._topBound;
+        var bottomBound = this._bottomBound;
+        var offsetY = y - this.props.offset;
+        var to = this.props.to;
+        var isInside = (offsetY >= topBound && offsetY <= bottomBound);
+        var isOutside = (offsetY < topBound || offsetY > bottomBound);
+        var activeLink = scroller.getActiveLink();
+
+        if (isOutside && activeLink === to) {
+          scroller.setActiveLink(void 0);
+          this.setState({ active : false });
+
+        } else if (isInside && activeLink != to) {
+          scroller.setActiveLink(to);
+          this.setState({ active : true });
+
+          if(this.props.onSetActive) {
+            this.props.onSetActive(to);
+          }
+
+          scrollSpy.updateStates();
+        }
       },
+
+      componentDidMount: function() {
+        if (this.props.spy) {
+          scrollSpy.mount(this.stateHandler, this.spyHandler);
+        }
+      },
+
+      componentWillUnmount: function() {
+        scrollSpy.unmount(this.stateHandler, this.spyHandler);
+      },
+
       render: function() {
         var className = "";
         if(this.state && this.state.active) {
@@ -131,6 +126,7 @@ var Helpers = {
       propTypes: {
         name: React.PropTypes.string.isRequired
       },
+
       componentDidMount: function() {
         var domNode = ReactDOM.findDOMNode(this);
         scroller.register(this.props.name, domNode);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -59,14 +59,10 @@ var Helpers = {
       },
 
       spyHandler: function(y) {
-        if(typeof this._topBound === 'undefined') {
-          var element = scroller.get(this.props.to);
-          var cords = element.getBoundingClientRect();
-          this._topBound = cords.top + y;
-          this._bottomBound = this._topBound + cords.height;
-        }
-        var topBound = this._topBound;
-        var bottomBound = this._bottomBound;
+        var element = scroller.get(this.props.to);
+        var cords = element.getBoundingClientRect();
+        var topBound = cords.top + y;
+        var bottomBound = topBound + cords.height;
         var offsetY = y - this.props.offset;
         var to = this.props.to;
         var isInside = (offsetY >= topBound && offsetY <= bottomBound);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -126,6 +126,8 @@ var Helpers = {
       componentDidMount: function() {
         var domNode = ReactDOM.findDOMNode(this);
         scroller.register(this.props.name, domNode);
+        // Whenever we add a scroll element, recalculate link active states
+        scrollSpy.initStates()
       },
       componentWillUnmount: function() {
         scroller.unregister(this.props.name);

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -22,13 +22,13 @@ var scrollSpy = {
   },
 
   hasHandlers: function() {
-    return this.spyCallbacks.length || this.spySetState.length
+    return this.spyCallbacks.length || this.spySetState.length;
   },
 
   addHandler: function(queueKey, handler) {
     if (handler && this[queueKey]) {
       if (document && !this.hasHandlers()) {
-        this._scrollHandler = this.scrollHandler.bind(this)
+        this._scrollHandler = this.scrollHandler.bind(this);
         document.addEventListener('scroll', this._scrollHandler);
       }
       this[queueKey].push(handler);

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,13 +1,13 @@
 var scrollSpy = {
-  
+
   spyCallbacks: [],
   spySetState: [],
 
-  mount: function () {
-    if (typeof document !== 'undefined') {
-      document.addEventListener('scroll', this.scrollHandler.bind(this));
-    }
+  mount: function (stateHandler, spyHandler) {
+    this.addHandler('spySetState', stateHandler);
+    this.addHandler('spyCallbacks', spyHandler);
   },
+
   currentPositionY: function () {
     var supportPageOffset = window.pageXOffset !== undefined;
     var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
@@ -21,12 +21,29 @@ var scrollSpy = {
     }
   },
 
-  addStateHandler: function(handler){
-    this.spySetState.push(handler);
+  hasHandlers: function() {
+    return this.spyCallbacks.length || this.spySetState.length
   },
 
-  addSpyHandler: function(handler){
-    this.spyCallbacks.push(handler);
+  addHandler: function(queueKey, handler) {
+    if (handler && this[queueKey]) {
+      if (document && !this.hasHandlers()) {
+        this._scrollHandler = this.scrollHandler.bind(this)
+        document.addEventListener('scroll', this._scrollHandler);
+      }
+      this[queueKey].push(handler);
+    }
+  },
+
+  removeHandler: function(queueKey, handler) {
+    var queue = this[queueKey] || [];
+    var i = queue.indexOf(handler);
+    if (i !== -1) {
+      this[queueKey] = queue.splice(i, 1);
+    }
+    if (document && !this.hasHandlers()) {
+      document.removeEventListener('scroll', this._scrollHandler);
+    }
   },
 
   updateStates: function(){

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -46,14 +46,23 @@ var scrollSpy = {
     }
   },
 
-  updateStates: function(){
+  updateStates: function() {
     var length = this.spySetState.length;
 
     for(var i = 0; i < length; i++) {
       this.spySetState[i]();
     }
   },
-  unmount: function () { 
+
+  initStates: function() {
+    var length = this.spyCallbacks.length;
+    var y = this.currentPositionY();
+    for(var i = 0; i < length; i++) {
+      this.spyCallbacks[i](y);
+    }
+  },
+
+  unmount: function () {
     this.spyCallbacks = [];
     this.spySetState = [];
 


### PR DESCRIPTION
Branched from fisshy/react-scroll#59

Currently link active states are not calculated until the first scroll event occurs. This change calculates link active states whenever scroll elements are first mounted (so the active state will already be set on a fresh page load)