### PR TITLE
Handling of elements with dynamic height, for example accordions

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -90,6 +90,7 @@ var Helpers = {
           var element = null;
           var elemTopBound = 0;
           var elemBottomBound = 0;
+          var cords = null;
 
           scrollSpy.addStateHandler((function() {
             if(scroller.getActiveLink() != to) {
@@ -98,14 +99,18 @@ var Helpers = {
           }).bind(this));
 
           scrollSpy.addSpyHandler((function(y) {
-
+            
             if(!element) {
                 element = scroller.get(to);
-
-                var cords = element.getBoundingClientRect();
-                elemTopBound = (cords.top + y);
-                elemBottomBound = elemTopBound + cords.height;
+                cords = element.getBoundingClientRect();
+                
+            } else {
+                cords = element.getBoundingClientRect();
             }
+            
+            elemTopBound = (cords.top + y);
+            elemBottomBound = elemTopBound + cords.height;
+
 
             var offsetY = y - this.props.offset;
             var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);


### PR DESCRIPTION
I had a problem with react-scroll. I used accordions in my project. If scroll the page, return to the top, and after that open an accordion then if you scroll manually again you will see that elements getting active in wrong places.
I familiarized with issues #49 and #59 but that problem does not solved. So I tried solve that issue myself.