### PR TITLE
Use accessor method in scroller

### DIFF
--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -36,7 +36,7 @@ module.exports = {
      * get the mapped DOM element
      */
 
-      var target = __mapped[to];
+      var target = this.get(to);
 
       if(!target) {
         throw new Error("target Element not found");


### PR DESCRIPTION
Use accessor to get scrolling element.

It helps to control returning element. For example to find element in DOM by anchor/id.