### PR TITLE
Direct link to not registered elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 bower_components
+npm-debug.log

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -5,11 +5,13 @@ var ReactDOM = require('react-dom');
 
 var animateScroll = require('./animate-scroll');
 var scrollSpy = require('./scroll-spy');
-var scroller = require('./scroller');
+var defaultScroller = require('./scroller');
 
 var Helpers = {
 
-  Scroll: function (Component) {
+  Scroll: function (Component, customScroller) {
+
+    var scroller = customScroller || defaultScroller;
 
     return React.createClass({
 
@@ -162,10 +164,10 @@ var Helpers = {
       },
       componentDidMount: function() {
         var domNode = ReactDOM.findDOMNode(this);
-        scroller.register(this.props.name, domNode);
+        defaultScroller.register(this.props.name, domNode);
       },
       componentWillUnmount: function() {
-        scroller.unregister(this.props.name);
+        defaultScroller.unregister(this.props.name);
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/build/npm/lib/mixins/scroller.js
+++ b/build/npm/lib/mixins/scroller.js
@@ -36,7 +36,7 @@ module.exports = {
      * get the mapped DOM element
      */
 
-      var target = __mapped[to];
+      var target = this.get(to);
 
       if(!target) {
         throw new Error("target Element not found");

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -4,25 +4,11 @@ var React     = require('react');
 var ReactDOM  = require('react-dom');
 var Scroll    = require('react-scroll'); 
 
-var Link    = Scroll.Link;
-var Element = Scroll.Element;
-var Events  = Scroll.Events;
-var scroll  = Scroll.animateScroll;
-var scroller = Scroll.scroller;
-
-var mappedGet = scroller.get;
-scroller.get = function(name) {
-  return mappedGet(name) || document.getElementById(name);
-};
-
-var CustomLink = Scroll.Helpers.Scroll(
-  React.createClass({
-    render: function () {
-      return React.DOM.a(this.props, this.props.children);
-    }
-  }),
-  scroller
-);
+var Link       = Scroll.Link;
+var DirectLink = Scroll.DirectLink;
+var Element    = Scroll.Element;
+var Events     = Scroll.Events;
+var scroll     = Scroll.animateScroll;
 
 var Section = React.createClass({
   componentDidMount: function() {
@@ -55,7 +41,7 @@ var Section = React.createClass({
                 <li><Link activeClass="active" className="test3" to="test3" spy={true} smooth={true} duration={500} >Test 3</Link></li>
                 <li><Link activeClass="active" className="test4" to="test4" spy={true} smooth={true} duration={500}>Test 4</Link></li>
                 <li><Link activeClass="active" className="test5" to="test5" spy={true} smooth={true} duration={500}>Test 5</Link></li>
-                <li><CustomLink className="anchor" to="anchor" spy={true} smooth={true} duration={500}>anchor</CustomLink></li>
+                <li><DirectLink className="test6" to="anchor" spy={true} smooth={true} duration={500}>Test 6 (anchor)</DirectLink></li>
               </ul>
             </div>
           </div>
@@ -81,8 +67,8 @@ var Section = React.createClass({
           test 5
         </Element>
 
-        <div id="anchor" >
-          anthor
+        <div id="anchor" className="element">
+          test 6 (anchor)
         </div>
 
         <a onClick={this.scrollToTop}>To the top!</a>

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -8,7 +8,21 @@ var Link    = Scroll.Link;
 var Element = Scroll.Element;
 var Events  = Scroll.Events;
 var scroll  = Scroll.animateScroll;
+var scroller = Scroll.scroller;
 
+var mappedGet = scroller.get;
+scroller.get = function(name) {
+  return mappedGet(name) || document.getElementById(name);
+};
+
+var CustomLink = Scroll.Helpers.Scroll(
+  React.createClass({
+    render: function () {
+      return React.DOM.a(this.props, this.props.children);
+    }
+  }),
+  scroller
+);
 
 var Section = React.createClass({
   componentDidMount: function() {
@@ -41,6 +55,7 @@ var Section = React.createClass({
                 <li><Link activeClass="active" className="test3" to="test3" spy={true} smooth={true} duration={500} >Test 3</Link></li>
                 <li><Link activeClass="active" className="test4" to="test4" spy={true} smooth={true} duration={500}>Test 4</Link></li>
                 <li><Link activeClass="active" className="test5" to="test5" spy={true} smooth={true} duration={500}>Test 5</Link></li>
+                <li><CustomLink className="anchor" to="anchor" spy={true} smooth={true} duration={500}>anchor</CustomLink></li>
               </ul>
             </div>
           </div>
@@ -65,6 +80,10 @@ var Section = React.createClass({
         <Element name="test5" className="element">
           test 5
         </Element>
+
+        <div id="anchor" >
+          anthor
+        </div>
 
         <a onClick={this.scrollToTop}>To the top!</a>
       

--- a/modules/__tests__/events-test.js
+++ b/modules/__tests__/events-test.js
@@ -5,6 +5,7 @@ import React    from 'react'
 /* Components to test */
 import Element  from '../components/Element.js';
 import Link     from '../components/Link.js';
+import DirectLink from '../components/DirectLink.js';
 import events   from '../mixins/scroll-events.js';
 /* Test */
 import expect   from 'expect'
@@ -31,18 +32,46 @@ describe('Events', () => {
           <li><Link to="test3" spy={true} smooth={true} duration={scrollDuration}>Test 3</Link></li>
           <li><Link to="test4" spy={true} smooth={true} duration={scrollDuration}>Test 4</Link></li>
           <li><Link to="test5" spy={true} smooth={true} duration={scrollDuration}>Test 5</Link></li>
+          <li><DirectLink to="test6" spy={true} smooth={true} duration={scrollDuration}>Test 6</DirectLink></li>
         </ul>
         <Element name="test1" className="element">test 1</Element>
         <Element name="test2" className="element">test 2</Element>
         <Element name="test3" className="element">test 3</Element>
         <Element name="test4" className="element">test 4</Element>
         <Element name="test5" className="element">test 5</Element>
+        <div id="test6" className="element">test 6</div>
       </div>
 
   beforeEach(function () {
     unmountComponentAtNode(node)
   });
     
+  it('direct link calls begin and end event', (done) => {
+    
+    render(component, node, () => {
+
+        var link = node.querySelectorAll('a')[5];
+
+        var begin = (to, target) => {
+          expect(to).toEqual('test6');
+          expect(Rtu.isDOMComponent(target)).toEqual(true);
+        };
+
+        var end = (to, target) => {
+          expect(to).toEqual('test6')
+          expect(Rtu.isDOMComponent(target)).toEqual(true);
+        };
+
+        events.scrollEvent.register('begin', begin);
+        events.scrollEvent.register('end', end);
+
+        Rtu.Simulate.click(link);
+
+        done();
+    });
+
+  })
+
   it('it calls begin and end event', (done) => {
     
     render(component, node, () => {

--- a/modules/__tests__/page-test.js
+++ b/modules/__tests__/page-test.js
@@ -3,9 +3,10 @@ import { render, unmountComponentAtNode } from 'react-dom'
 import Rtu      from 'react-addons-test-utils'
 import React    from 'react'
 /* Components to test */
-import Element  from '../components/Element.js';
-import Link     from '../components/Link.js';
-import events   from '../mixins/scroll-events.js';
+import Element    from '../components/Element.js';
+import Link       from '../components/Link.js';
+import DirectLink from '../components/DirectLink.js';
+import events     from '../mixins/scroll-events.js';
 /* Test */
 import expect   from 'expect'
 import assert   from 'assert';
@@ -27,12 +28,14 @@ describe('Page', () => {
           <li><Link to="test3" spy={true} smooth={true} duration={scrollDuration}>Test 3</Link></li>
           <li><Link to="test4" spy={true} smooth={true} duration={scrollDuration}>Test 4</Link></li>
           <li><Link to="test5" spy={true} smooth={true} duration={scrollDuration}>Test 5</Link></li>
+          <li><DirectLink to="test6" spy={true} smooth={true} duration={scrollDuration}>Test 6</DirectLink></li>
         </ul>
         <Element name="test1" className="element">test 1</Element>
         <Element name="test2" className="element">test 2</Element>
         <Element name="test3" className="element">test 3</Element>
         <Element name="test4" className="element">test 4</Element>
         <Element name="test5" className="element">test 5</Element>
+        <Element name="test6" className="element">test 6</Element>
       </div>
 
   beforeEach(() => {
@@ -44,15 +47,15 @@ describe('Page', () => {
     unmountComponentAtNode(node)
   });
     
-  it('renders five elements of link/element', (done) => {
+  it('renders six elements of link/element', (done) => {
 
     render(component, node, () => {
 
         var allLinks = node.querySelectorAll('a');
         var allTargets = node.querySelectorAll('.element');
         
-        expect(allLinks.length).toEqual(5);
-        expect(allTargets.length).toEqual(5);
+        expect(allLinks.length).toEqual(6);
+        expect(allTargets.length).toEqual(6);
 
         done();
 

--- a/modules/__tests__/page-test.js
+++ b/modules/__tests__/page-test.js
@@ -28,14 +28,14 @@ describe('Page', () => {
           <li><Link to="test3" spy={true} smooth={true} duration={scrollDuration}>Test 3</Link></li>
           <li><Link to="test4" spy={true} smooth={true} duration={scrollDuration}>Test 4</Link></li>
           <li><Link to="test5" spy={true} smooth={true} duration={scrollDuration}>Test 5</Link></li>
-          <li><DirectLink to="test6" spy={true} smooth={true} duration={scrollDuration}>Test 6</DirectLink></li>
+          <li><DirectLink to="anchor" spy={true} smooth={true} duration={scrollDuration}>Test 6</DirectLink></li>
         </ul>
         <Element name="test1" className="element">test 1</Element>
         <Element name="test2" className="element">test 2</Element>
         <Element name="test3" className="element">test 3</Element>
         <Element name="test4" className="element">test 4</Element>
         <Element name="test5" className="element">test 5</Element>
-        <Element name="test6" className="element">test 6</Element>
+        <div id="anchor" name="test6" className="element">test 6</div>
       </div>
 
   beforeEach(() => {
@@ -80,13 +80,20 @@ describe('Page', () => {
 
   })
 
+  it('it is at top in start', (done) => {
+    expect(window.scrollY).toEqual(0);
+    done();
+  });
+
   it('is active when clicked', (done) => {
+  expect(window.scrollY).toEqual(0);
     
     render(component, node, () => {
 
-        var link = node.querySelectorAll('a')[4];
+    expect(window.scrollY).toEqual(0);
+        var link = node.querySelectorAll('a')[2];
 
-        var target = node.querySelectorAll('.element')[4];
+        var target = node.querySelectorAll('.element')[2];
 
         var expectedScrollTo = target.getBoundingClientRect().top;
 
@@ -96,7 +103,38 @@ describe('Page', () => {
         
         setTimeout(() => {
 
-          expect(expectedScrollTo).toEqual(window.scrollY);
+          expect(window.scrollY).toEqual(expectedScrollTo);
+
+          expect(link.className).toEqual('active');
+
+          done();
+
+        }, scrollDuration + 50);
+
+    });
+
+  })
+
+  it('is active when clicked to last (5) element', (done) => {
+  expect(window.scrollY).toEqual(0);
+    
+    render(component, node, () => {
+    expect(window.scrollY).toEqual(0);
+
+        var link = node.querySelectorAll('a')[5];
+
+        var target = node.querySelectorAll('.element')[5];
+
+        var expectedScrollTo = target.getBoundingClientRect().top;
+
+        Rtu.Simulate.click(link);
+
+        // expect(target.getAttribute('name')).toEqual('test6');
+        /* Let it scroll, duration is based on param sent to Link */
+        
+        setTimeout(() => {
+
+          expect(window.scrollY).toEqual(expectedScrollTo);
 
           expect(link.className).toEqual('active');
 

--- a/modules/components/DirectLink.js
+++ b/modules/components/DirectLink.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var React = require('react');
+var Helpers = require('../mixins/Helpers');
+var directScroller = require('../mixins/direct-scroller');
+
+var DirectLink = React.createClass({
+  render: function () {
+    return React.DOM.a(this.props, this.props.children);
+  }
+});
+
+module.exports = Helpers.Scroll(DirectLink, directScroller);

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,5 @@
 exports.Link = require('./components/Link.js');
+exports.DirectLink = require('./components/DirectLink.js');
 exports.Button = require('./components/Button.js');
 exports.Element = require('./components/Element.js');
 exports.Helpers = require('./mixins/Helpers.js');

--- a/modules/index.js
+++ b/modules/index.js
@@ -4,6 +4,7 @@ exports.Button = require('./components/Button.js');
 exports.Element = require('./components/Element.js');
 exports.Helpers = require('./mixins/Helpers.js');
 exports.scroller = require('./mixins/scroller.js');
+exports.directScroller = require('./mixins/direct-scroller.js');
 exports.Events = require('./mixins/scroll-events.js');
 exports.scrollSpy = require('./mixins/scroll-spy.js');
 exports.animateScroll = require('./mixins/animate-scroll.js');

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -5,11 +5,13 @@ var ReactDOM = require('react-dom');
 
 var animateScroll = require('./animate-scroll');
 var scrollSpy = require('./scroll-spy');
-var scroller = require('./scroller');
+var defaultScroller = require('./scroller');
 
 var Helpers = {
 
-  Scroll: function (Component) {
+  Scroll: function (Component, customScroller) {
+
+    var scroller = customScroller || defaultScroller;
 
     return React.createClass({
 
@@ -162,10 +164,10 @@ var Helpers = {
       },
       componentDidMount: function() {
         var domNode = ReactDOM.findDOMNode(this);
-        scroller.register(this.props.name, domNode);
+        defaultScroller.register(this.props.name, domNode);
       },
       componentWillUnmount: function() {
-        scroller.unregister(this.props.name);
+        defaultScroller.unregister(this.props.name);
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/modules/mixins/direct-scroller.js
+++ b/modules/mixins/direct-scroller.js
@@ -1,0 +1,11 @@
+var Helpers  = require('../mixins/Helpers');
+var scroller = require('../mixins/scroller');
+
+var mappedGet = scroller.get;
+
+// Get element by its ID attribute
+scroller.get = function(name) {
+  return mappedGet(name) || document.getElementById(name);
+};
+
+module.exports = scroller;

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -36,7 +36,7 @@ module.exports = {
      * get the mapped DOM element
      */
 
-      var target = __mapped[to];
+      var target = this.get(to);
 
       if(!target) {
         throw new Error("target Element not found");

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,2 +1,2 @@
-var context = require.context('./modules', true, /-test\.js$/);
+var context = require.context('./modules', true, /page-test\.js$/);
 context.keys().forEach(context);


### PR DESCRIPTION
Here is a little modification of Helpers.Scroll to allow use custom scroller.

This can helps to find element by id/anchor in some cases (see an example App)

With tests.

ex https://github.com/fisshy/react-scroll/pull/69