### PR TITLE
Add scrollTo(position), scrollMore(px) and scrollToBottom() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ var Section = React.createClass({
   scrollToTop: function() {
     scroll.scrollToTop();
   },
+  scrollTo: function() {
+    scroll.scrollTo(100);
+  },
+  scrollMore: function() {
+    scroll.scrollMore(10);
+  },
   render: function () {
   	return (
       <div>
@@ -71,6 +77,10 @@ var Section = React.createClass({
         </div>
 
         <a onClick={this.scrollToTop}>To the top!</a>
+        <br/>
+        <a onClick={this.scrollTo}>Scroll to 100px from the top</a>
+        <br/>
+        <a onClick={this.scrollMore}>Scroll 10px more from the current position!</a>
       </div>
 	);
   }
@@ -80,6 +90,41 @@ React.render(
   <Section />,
   document.getElementById('example')
 );
+
+```
+
+### Scroll Methods
+
+> Scroll To Top
+
+```js
+
+var Scroll = require('react-scroll');
+var scroll = Scroll.animateScroll;
+
+scroll.scrollToTop();
+
+```
+
+> Scroll To (px)
+
+```js
+
+var Scroll = require('react-scroll');
+var scroll = Scroll.animateScroll;
+
+scroll.scrollTo(100);
+
+```
+
+> Scroll More (px)
+
+```js
+
+var Scroll = require('react-scroll');
+var scroll = Scroll.animateScroll;
+
+scroll.scrollMore(10);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ var Section = React.createClass({
 
         <a onClick={this.scrollToTop}>To the top!</a>
         <br/>
+        <a onClick={this.scrollToTop}>To bottom!</a>
+        <br/>
         <a onClick={this.scrollTo}>Scroll to 100px from the top</a>
         <br/>
         <a onClick={this.scrollMore}>Scroll 10px more from the current position!</a>
@@ -103,6 +105,17 @@ var Scroll = require('react-scroll');
 var scroll = Scroll.animateScroll;
 
 scroll.scrollToTop();
+
+```
+
+> Scroll To Bottom
+
+```js
+
+var Scroll = require('react-scroll');
+var scroll = Scroll.animateScroll;
+
+scroll.scrollToBottom();
 
 ```
 

--- a/modules/__tests__/animate-scroll-test.js
+++ b/modules/__tests__/animate-scroll-test.js
@@ -1,0 +1,133 @@
+import {render, unmountComponentAtNode} from 'react-dom'
+import Rtu      from 'react-addons-test-utils'
+import React    from 'react'
+
+import expect from 'expect'
+import animateScroll from '../mixins/animate-scroll';
+import events from '../mixins/scroll-events.js';
+
+var currentPositionY = function () {
+  var supportPageOffset = window.pageXOffset !== undefined;
+  var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+  return supportPageOffset ? window.pageYOffset : isCSS1Compat ?
+      document.documentElement.scrollTop : document.body.scrollTop;
+};
+
+describe('AnimateScroll', () => {
+
+  let node = document.createElement('div');
+
+  document.body.innerHtml = "";
+
+  document.body.appendChild(node);
+
+  const duration = 10;
+
+  // the bigger the difference between the 2 the better,
+  // For some reason, sometimes test just fail because the animation did complete in time!
+  const waitDuration = duration * 5;
+
+  let tallComponent =
+      <div id="hugeComponent">
+        <a onClick={() => animateScroll.scrollToTop()}>Scroll To Top!</a>
+        <a onClick={() => animateScroll.scrollTo(100)}>Scroll To 100!</a>
+        <a onClick={() => animateScroll.scrollMore(10)}>Scroll More!</a>
+        <div style={{height: '10000px'}}></div>
+      </div>
+
+  beforeEach(function () {
+    window.scrollTo(0, 0);
+
+    unmountComponentAtNode(node);
+  });
+
+  it('renders a component taller than the window height', () => {
+    render(tallComponent, node, () => {
+      expect(node.offsetHeight > window.innerHeight).toBe(true);
+    });
+  });
+
+  it('scrolls to an absolute position', (done) => {
+    render(tallComponent, node, () => {
+      animateScroll.scrollTo(120, duration);
+
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(120);
+        done();
+      }, waitDuration);
+    });
+  });
+
+  it('scrolls to an absolute position even if current position is higher', (done) => {
+    render(tallComponent, node, () => {
+      window.scrollTo(0, 1000);
+      animateScroll.scrollTo(200, duration);
+
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(200);
+
+        done();
+      }, waitDuration);
+
+    });
+  });
+
+  it('scrolls to top', (done) => {
+    render(tallComponent, node, () => {
+      window.scrollTo(0, 1000);
+      animateScroll.scrollToTop(duration);
+
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(0);
+        done();
+      }, waitDuration);
+    });
+  });
+
+  it('scrolls to bottom', (done) => {
+    render(tallComponent, node, () => {
+      animateScroll.scrollToBottom(duration);
+
+      setTimeout(() => {
+        var offset = 16;
+
+        expect(window.scrollY).toEqual(node.offsetHeight - window.innerHeight + offset);
+        done();
+      }, waitDuration);
+    });
+  });
+
+  it('scrolls to a position relative to the current position', (done) => {
+    render(tallComponent, node, () => {
+      window.scrollTo(0, 111);
+
+      animateScroll.scrollMore(10, duration);
+
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(121);
+
+        animateScroll.scrollMore(10, duration);
+
+        // do it again!
+        setTimeout(() => {
+          expect(window.scrollY).toEqual(131);
+
+          done();
+        }, waitDuration);
+
+      }, waitDuration);
+    });
+  });
+
+  it('can take 0 as a duration argument', (done) => {
+    render(tallComponent, node, () => {
+      animateScroll.scrollTo(120, 0);
+
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(120);
+        done();
+      }, 1);
+    });
+  });
+
+});

--- a/modules/__tests__/events-test.js
+++ b/modules/__tests__/events-test.js
@@ -7,17 +7,15 @@ import Element  from '../components/Element.js';
 import Link     from '../components/Link.js';
 import DirectLink from '../components/DirectLink.js';
 import events   from '../mixins/scroll-events.js';
+import animateScroll from '../mixins/animate-scroll.js';
 /* Test */
 import expect   from 'expect'
 import assert   from 'assert';
 
 
 describe('Events', () => {
-  
-  console.log("test");
 
   let node = document.createElement('div');
-  
   document.body.innerHtml = "";
 
   document.body.appendChild(node)
@@ -43,9 +41,15 @@ describe('Events', () => {
       </div>
 
   beforeEach(function () {
-    unmountComponentAtNode(node)
+    unmountComponentAtNode(node);
   });
-    
+
+  afterEach(() => {
+    // clean up the events after each test
+    events.scrollEvent.remove('begin');
+    events.scrollEvent.remove('end');
+  });
+
   it('direct link calls begin and end event', (done) => {
     
     render(component, node, () => {
@@ -70,10 +74,10 @@ describe('Events', () => {
         done();
     });
 
-  })
+  });
 
   it('it calls begin and end event', (done) => {
-    
+
     render(component, node, () => {
 
         var link = node.querySelectorAll('a')[2];
@@ -93,9 +97,27 @@ describe('Events', () => {
 
         Rtu.Simulate.click(link);
 
-        done();
+
+        // wait to actually scroll so it doesn't affect the next test!
+        setTimeout(() => {
+          done();
+        }, scrollDuration * 3);
     });
 
-  })
+  });
+
+  it('calls "end" event on scrollTo', (done) => {
+    render(component, node, () => {
+
+      var end = (to, target, endPosition) => {
+        expect(endPosition).toEqual(100);
+        done();
+      };
+
+      events.scrollEvent.register('end', end);
+
+      animateScroll.scrollTo(100, scrollDuration);
+    });
+  });
 
 });

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -87,8 +87,8 @@ var startAnimateTopScroll = function(y, options, to, target) {
   __start           = null;
   __cancel          = false;
   __startPositionY  = currentPositionY();
-  __targetPositionY = y + __startPositionY;
-  __duration        = options.duration || 1000;
+  __targetPositionY = y;
+  __duration        = options.duration || 300;
   __to              = to;
   __target          = target;
 
@@ -96,10 +96,20 @@ var startAnimateTopScroll = function(y, options, to, target) {
 };
 
 var scrollToTop = function (duration) {
-  startAnimateTopScroll(-currentPositionY(), { duration : duration || 1000 });
+  startAnimateTopScroll(0, { duration : duration || 1000 });
+};
+
+var scrollTo = function (toY, duration) {
+  startAnimateTopScroll(toY, { duration : duration });
+};
+
+var scrollMore = function(toY, duration) {
+  startAnimateTopScroll(currentPositionY() + toY, { duration : duration });
 };
 
 module.exports = {
   animateTopScroll: startAnimateTopScroll,
-  scrollToTop: scrollToTop
+  scrollToTop: scrollToTop,
+  scrollTo: scrollTo,
+  scrollMore: scrollMore,
 };

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -54,6 +54,19 @@ var currentPositionY = function() {
          document.documentElement.scrollTop : document.body.scrollTop;
 };
 
+var pageHeight = function() {
+  var body = document.body;
+  var html = document.documentElement;
+
+  return Math.max(
+      body.scrollHeight,
+      body.offsetHeight,
+      html.clientHeight,
+      html.scrollHeight,
+      html.offsetHeight
+  );
+};
+
 var animateTopScroll = function(timestamp) {
   // Cancel on specific events
   if(__cancel) { return };
@@ -78,7 +91,7 @@ var animateTopScroll = function(timestamp) {
   }
 
   if(events.registered['end']) {
-    events.registered['end'](__to, __target);
+    events.registered['end'](__to, __target, __currentPositionY);
   }
 
 };
@@ -88,7 +101,7 @@ var startAnimateTopScroll = function(y, options, to, target) {
   __cancel          = false;
   __startPositionY  = currentPositionY();
   __targetPositionY = y;
-  __duration        = options.duration || 300;
+  __duration        = isNaN(parseFloat(options.duration)) ? 1000 : parseFloat(options.duration);
   __to              = to;
   __target          = target;
 
@@ -96,11 +109,15 @@ var startAnimateTopScroll = function(y, options, to, target) {
 };
 
 var scrollToTop = function (duration) {
-  startAnimateTopScroll(0, { duration : duration || 1000 });
+  startAnimateTopScroll(0, { duration : duration });
 };
 
 var scrollTo = function (toY, duration) {
   startAnimateTopScroll(toY, { duration : duration });
+};
+
+var scrollToBottom = function(duration) {
+  startAnimateTopScroll(pageHeight(), { duration : duration });
 };
 
 var scrollMore = function(toY, duration) {
@@ -110,6 +127,7 @@ var scrollMore = function(toY, duration) {
 module.exports = {
   animateTopScroll: startAnimateTopScroll,
   scrollToTop: scrollToTop,
+  scrollToBottom: scrollToBottom,
   scrollTo: scrollTo,
   scrollMore: scrollMore,
 };


### PR DESCRIPTION
This PR adds 2 new methods:
- **scrollTo**
  Makes it super easy to scroll to an absolute position from the top

- **scrollMore**
  Allows scrolling to a relative position from the current scroll position. 

The reason I didn't like to use the provided animateTopScroll, is because it behaves as scrollMore rather than scrollTo. If one needs to scroll to an absolute position from the top, it needs to do the math at the implementation level, which is not that nice.'

I'm also thinking of adding a **scrollToBottom** method, to avoid the above mentioned math calculations when you need to scroll to bottom.
