### PR TITLE
Add missing dep `object-assign`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scrolls"
   ],
   "dependencies": {
+    "object-assign": "^4.0.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7"
   },


### PR DESCRIPTION
`modules/mixins/animate-scroll.js` requires `object-assign`, but the
relevant package is not in `package.json`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisshy/react-scroll/73)
<!-- Reviewable:end -->
