### PR TITLE
Expose isDynamic prop to recalculate the element coordinates

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -19,6 +19,7 @@ var Helpers = {
         to: React.PropTypes.string.isRequired,
         offset: React.PropTypes.number,
         delay: React.PropTypes.number,
+        isDynamic: React.PropTypes.bool,
         onClick: React.PropTypes.func,
         duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func])
       },
@@ -103,7 +104,7 @@ var Helpers = {
 
           scrollSpy.addSpyHandler((function(y) {
 
-            if(!element) {
+            if(!element || this.props.isDynamic) {
                 element = scroller.get(to);
                 if(!element){ return;}
 


### PR DESCRIPTION
Added isDynamic prop that will recalculate the element coordinates. Our web page has dynamic components like accordions. Incorrect navigation items are being highlighted after expanding the accordion for example. 