### PR TITLE
Make event listeners passive

### DIFF
--- a/modules/mixins/cancel-events.js
+++ b/modules/mixins/cancel-events.js
@@ -1,3 +1,5 @@
+var addPassiveEventListener = require('./passive-event-listeners');
+
 var events = ['mousedown', 'mousewheel', 'touchmove', 'keydown']
 
 module.exports = {
@@ -7,7 +9,7 @@ module.exports = {
 		}
 
 		for(var i = 0; i < events.length; i = i + 1) {
-			document.addEventListener(events[i], cancelEvent);
+			addPassiveEventListener(document, events[i], cancelEvent);
 		}
 	}
 };

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -1,0 +1,23 @@
+/*
+ * Tell the browser that the event listener won't prevent a scroll.
+ * Allowing the browser to continue scrolling without having to
+ * to wait for the listener to return.
+ */
+var addPassiveEventListener = function(target, eventName, listener) {
+    var supportsPassiveOption = (function(){
+        var supportsPassiveOption = false;
+        try {
+            var opts = Object.defineProperty({}, 'passive', {
+                get: function() {
+                    supportsPassiveOption = true;
+                }
+            });
+            window.addEventListener('test', null, opts);
+        } catch (e) {}
+        return supportsPassiveOption;
+    })();
+
+    target.addEventListener(eventName, listener, supportsPassiveOption ? {passive: true} : false);
+};
+
+module.exports = addPassiveEventListener;

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,3 +1,5 @@
+var addPassiveEventListener = require('./passive-event-listeners');
+
 var eventThrottler = function(eventHandler) {
   var eventHandlerTimeout;
   return function(event) {
@@ -23,7 +25,7 @@ var scrollSpy = {
       var eventHandler = eventThrottler(function(event) {
   			t.scrollHandler(scrollSpyContainer);
   		});
-      scrollSpyContainer.addEventListener('scroll', eventHandler);
+      addPassiveEventListener(scrollSpyContainer, 'scroll', eventHandler);
     }
   },
   currentPositionY: function (scrollSpyContainer) {


### PR DESCRIPTION
Without the passive option the added event listeners makes scrolling hang in my case.

For more information about passive listeners, see https://developers.google.com/web/updates/2016/06/passive-event-listeners?hl=en

I can also amend a semver update. It would be convenient if this lands on NPM.