### PR TITLE
BUGFIX: fix the bug when 'elemTopBound' is decimal

### DIFF
--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -124,8 +124,8 @@ var Helpers = {
             }
 
             var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
+            var isInside = (offsetY >= Math.floor(elemTopBound) && offsetY <= Math.floor(elemBottomBound));
+            var isOutside = (offsetY < Math.floor(elemTopBound) || offsetY > Math.floor(elemBottomBound));
             var activeLink = scroller.getActiveLink();
 
             if (isOutside && activeLink === to) {

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -124,8 +124,8 @@ var Helpers = {
             }
 
             var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
+            var isInside = (offsetY >= Math.floor(elemTopBound) && offsetY <= Math.floor(elemBottomBound));
+            var isOutside = (offsetY < Math.floor(elemTopBound) || offsetY > Math.floor(elemBottomBound));
             var activeLink = scroller.getActiveLink();
 
             if (isOutside && activeLink === to) {


### PR DESCRIPTION
BUGFIX: while 'elemTopBound' is decimal, the 'isInside' would be false, and no 'ScrollLink' would be 'active';