### PR TITLE
BUGFIX: fix the bug that 'Element's will not scroll , while the second time u enter the component and click the 'Scroll' 

### DIFF
--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -150,6 +150,7 @@ var Helpers = {
       },
       componentWillUnmount: function() {
         scrollSpy.unmount();
+        animateScroll.resetContainer();
       },
       render: function() {
 
@@ -188,6 +189,7 @@ var Helpers = {
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+        animateScroll.resetContainer();
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -124,8 +124,8 @@ var Helpers = {
             }
 
             var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
+            var isInside = (offsetY >= Math.floor(elemTopBound) && offsetY <= Math.floor(elemBottomBound));
+            var isOutside = (offsetY < Math.floor(elemTopBound) || offsetY > Math.floor(elemBottomBound));
             var activeLink = scroller.getActiveLink();
 
             if (isOutside && activeLink === to) {

--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -177,10 +177,15 @@ var scrollMore = function(toY, options) {
   startAnimateTopScroll(currentPositionY() + toY, assign(options || {}, { absolute : true }));
 };
 
+var resetContainer = function() {
+  __containerElement = undefined;
+};
+
 module.exports = {
   animateTopScroll: startAnimateTopScroll,
   scrollToTop: scrollToTop,
   scrollToBottom: scrollToBottom,
   scrollTo: scrollTo,
   scrollMore: scrollMore,
+  resetContainer: resetContainer
 };

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -150,6 +150,7 @@ var Helpers = {
       },
       componentWillUnmount: function() {
         scrollSpy.unmount();
+        animateScroll.resetContainer();
       },
       render: function() {
 
@@ -188,6 +189,7 @@ var Helpers = {
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+        animateScroll.resetContainer();
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -124,8 +124,8 @@ var Helpers = {
             }
 
             var offsetY = y - this.props.offset;
-            var isInside = (offsetY >= elemTopBound && offsetY <= elemBottomBound);
-            var isOutside = (offsetY < elemTopBound || offsetY > elemBottomBound);
+            var isInside = (offsetY >= Math.floor(elemTopBound) && offsetY <= Math.floor(elemBottomBound));
+            var isOutside = (offsetY < Math.floor(elemTopBound) || offsetY > Math.floor(elemBottomBound));
             var activeLink = scroller.getActiveLink();
 
             if (isOutside && activeLink === to) {

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -177,10 +177,15 @@ var scrollMore = function(toY, options) {
   startAnimateTopScroll(currentPositionY() + toY, assign(options || {}, { absolute : true }));
 };
 
+var resetContainer = function() {
+  __containerElement = undefined;
+};
+
 module.exports = {
   animateTopScroll: startAnimateTopScroll,
   scrollToTop: scrollToTop,
   scrollToBottom: scrollToBottom,
   scrollTo: scrollTo,
   scrollMore: scrollMore,
+  resetContainer: resetContainer
 };


### PR DESCRIPTION
I have a page which contains some component  using the `<ScrollLink>` and the `<Element>`.
*    When I first go into this page, I click one `<ScrollLink>` and the relevant `<Element>` will scroll to the top. 
*    Then I go to some other page, this component unmount. And I go back this page, this component amount again. Then I click the same one  `<ScrollLink>`, the relevant `<Element>` doesn't scroll any more. 

Finally, I find out that `__containerElement` don't release while I unmount the component with the `<ScrollLink>`s and the `<Element>`s.

Maybe there're some better way to solve it, but it works for me.