### PR TITLE
Recalculate target Y on elements that might be moving while scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ React.render(
 
 > isDynamic - in case the distance has to be recalculated - if you have content that expands etc.
 
+> mightMove - in case the scroll position of the target is changing while scrolling to it -
+if you have content that expands above the target at the same time as scrolling;
+works best if you match durations for the animations and the scrolling
+
 ```js
 <Link activeClass="active"
       to="target"

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -18,6 +18,7 @@ var protoTypes = {
   offset: React.PropTypes.number,
   delay: React.PropTypes.number,
   isDynamic: React.PropTypes.bool,
+  mightMove: React.PropTypes.bool,
   onClick: React.PropTypes.func,
   duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func])
 };

--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -57,6 +57,9 @@ var __start;
 var __deltaTop;
 var __percent;
 var __delayTimeout;
+var __mightMove;
+var __absolute;
+var __offset;
 
 
 var currentPositionY = function() {
@@ -96,6 +99,11 @@ var animateTopScroll = function(timestamp) {
   if(__cancel) { return };
 
   __deltaTop = Math.round(__targetPositionY - __startPositionY);
+
+  if (__mightMove){
+    __targetPositionY = __absolute ? __target.offsetTop : (__target.getBoundingClientRect().top + __currentPositionY);
+    __targetPositionY += (__offset || 0);
+  }
 
   if (__start === null) {
     __start = timestamp;
@@ -147,6 +155,9 @@ var startAnimateTopScroll = function(y, options, to, target) {
   __duration        = isNaN(parseFloat(__duration)) ? 1000 : parseFloat(__duration);
   __to              = to;
   __target          = target;
+  __mightMove       = options.mightMove;
+  __absolute        = options.absolute;
+  __offset          = options.offset;
 
   if(options && options.delay > 0) {
     __delayTimeout = window.setTimeout(function animate() {

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -33,6 +33,16 @@ var Section = React.createClass({
     Events.scrollEvent.remove('begin');
     Events.scrollEvent.remove('end');
   },
+  moveElement8: function(){
+    this.moveElement('element-8-spacer');
+  },
+  moveContainerElement: function(){
+    this.moveElement('container-element-spacer');
+  },
+  moveElement: function(id){
+    var element = document.getElementById(id);
+    element.style.height = element.style.height === "100px" ? 0 : "100px";
+  },
   render: function () {
     return (
       <div>
@@ -47,6 +57,7 @@ var Section = React.createClass({
                 <li><Link activeClass="active" className="test5" to="test5" spy={true} smooth={true} duration={500} delay={1000}>Test 5 ( delay )</Link></li>
                 <li><DirectLink className="test6" to="anchor" spy={true} smooth={true} duration={500}>Test 6 (anchor)</DirectLink></li>
                 <li><Link activeClass="active" className="test7" to="test7" spy={true} smooth={true} duration={durationFn}>Test 7 (duration and container)</Link></li>
+                <li><Link activeClass="active" className="test8" to="test8" spy={true} smooth={true} duration={500} onClick={this.moveElement8} mightMove={true}>Test 8 (moving)</Link></li>
                 <li> <a onClick={() => scroll.scrollTo(100)}>Scroll To 100!</a></li>
                 <li> <a onClick={() => scroll.scrollToBottom()}>Scroll To Bottom</a></li>
                 <li> <a onClick={() => scroll.scrollMore(500)}>Scroll 500 More!</a></li>
@@ -87,6 +98,9 @@ var Section = React.createClass({
         <Link activeClass="active" to="secondInsideContainer" spy={true} smooth={true} duration={250} containerId="containerElement" style={{display:'inline-block', margin: '20px'}}>
           Go to second element inside container
         </Link>
+        <Link activeClass="active" to="movingInsideContainer" spy={true} smooth={true} duration={500} containerId="containerElement" onClick={this.moveContainerElement} style={{display:'inline-block', margin: '20px'}} mightMove={true}>
+          Go to moving element inside container
+        </Link>
         <Element name="test7" className="element" id="containerElement" style={{
           position: 'relative',
           height:'200px',
@@ -106,6 +120,18 @@ var Section = React.createClass({
           }}>
             second element inside container
           </Element>
+
+          <div id="container-element-spacer" style={{transition: 'all 0.5s', height: '100px', background: 'darkorange'}}></div>
+          <Element name="movingInsideContainer"  style={{
+            marginBottom: '200px'
+          }}>
+            moving element inside container
+          </Element>
+        </Element>
+
+        <div id="element-8-spacer" style={{transition: 'all 0.5s', height: '100px', background: 'darkorange'}}></div>
+        <Element name="test8" className="element">
+          test 8 (moving)
         </Element>
 
         <a onClick={this.scrollToTop}>To the top!</a>

--- a/modules/__tests__/animate-scroll-test.js
+++ b/modules/__tests__/animate-scroll-test.js
@@ -33,6 +33,7 @@ describe('AnimateScroll', () => {
         <a onClick={() => animateScroll.scrollTo(100)}>Scroll To 100!</a>
         <a onClick={() => animateScroll.scrollMore(10)}>Scroll More!</a>
         <div style={{height: '10000px'}}></div>
+        <div id="target" style={{position: 'absolute', top: '100px', transition: 'all 250ms'}}></div>
       </div>
 
   afterEach(function () {
@@ -116,6 +117,20 @@ describe('AnimateScroll', () => {
         }, waitDuration);
 
       }, waitDuration);
+    });
+  });
+
+  it('scrolls to the right position even if the target is moving', (done) => {
+    render(tallComponent, node, () => {
+      var target = document.getElementById('target');
+      var coordinates = target.getBoundingClientRect();
+      // the process of animating and scrolling together needs a little more time to finish than the default tests
+      animateScroll.animateTopScroll(coordinates.top, { duration: 250, mightMove: true  }, target, target);
+      target.style.top = "110px";
+      setTimeout(() => {
+        expect(window.scrollY).toEqual(110);
+        done();
+      }, 300)
     });
   });
 

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -18,6 +18,7 @@ var protoTypes = {
   offset: React.PropTypes.number,
   delay: React.PropTypes.number,
   isDynamic: React.PropTypes.bool,
+  mightMove: React.PropTypes.bool,
   onClick: React.PropTypes.func,
   duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func])
 };

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -57,6 +57,9 @@ var __start;
 var __deltaTop;
 var __percent;
 var __delayTimeout;
+var __mightMove;
+var __absolute;
+var __offset;
 
 
 var currentPositionY = function() {
@@ -96,6 +99,11 @@ var animateTopScroll = function(timestamp) {
   if(__cancel) { return };
 
   __deltaTop = Math.round(__targetPositionY - __startPositionY);
+
+  if (__mightMove){
+    __targetPositionY = __absolute ? __target.offsetTop : (__target.getBoundingClientRect().top + __currentPositionY);
+    __targetPositionY += (__offset || 0);
+  }
 
   if (__start === null) {
     __start = timestamp;
@@ -147,6 +155,9 @@ var startAnimateTopScroll = function(y, options, to, target) {
   __duration        = isNaN(parseFloat(__duration)) ? 1000 : parseFloat(__duration);
   __to              = to;
   __target          = target;
+  __mightMove       = options.mightMove;
+  __absolute        = options.absolute;
+  __offset          = options.offset;
 
   if(options && options.delay > 0) {
     __delayTimeout = window.setTimeout(function animate() {


### PR DESCRIPTION
Let me know if this is something you're interested in adding.  I tried to match conventions and such, but haven't updated the README yet.  
- if the target being scrolled to is changing position while the scrolling is happening, the target position needs to be recalculated on the fly to ensure we end up at the right spot
- this might happen if clicking a scroll link triggers other actions in the DOM that affect the Y position of the target (such as collapsing an element above the target)
