### PR TITLE
Add `absolute` to protoTypes

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -19,7 +19,8 @@ var protoTypes = {
   delay: React.PropTypes.number,
   isDynamic: React.PropTypes.bool,
   onClick: React.PropTypes.func,
-  duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func])
+  duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func]),
+  absolute: React.PropTypes.bool
 };
 
 var Helpers = {


### PR DESCRIPTION
Fixes `Warning: Unknown prop `absolute` on <a> tag. Remove this prop from the element.`.