### PR TITLE
Adds missing onSetActive prop to propTypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ var Section = React.createClass({
   scrollMore: function() {
     scroll.scrollMore(100);
   },
+  handleSetActive: function(to) {
+    console.log(to);
+  },
   render: function () {
   	return (
       <div>
-        <Link activeClass="active" to="test1" spy={true} smooth={true} offset={50} duration={500} >
+        <Link activeClass="active" to="test1" spy={true} smooth={true} offset={50} duration={500} onSetActive={this.handleSetActive}>
           Test 1
         </Link>
         <Link activeClass="active" to="test1" spy={true} smooth={true} offset={50} duration={500} delay={1000}>
@@ -149,6 +152,8 @@ React.render(
 
 > isDynamic - in case the distance has to be recalculated - if you have content that expands etc.
 
+> onSetActive - invoke whenever link is being set to active
+
 ```js
 <Link activeClass="active"
       to="target"
@@ -158,6 +163,7 @@ React.render(
       duration={500}
       delay={1000}
       isDynamic={true}
+      onSetActive={this.handleSetActive}
 >
   Your name
 </Link>

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -20,7 +20,8 @@ var protoTypes = {
   isDynamic: React.PropTypes.bool,
   onClick: React.PropTypes.func,
   duration: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.func]),
-  absolute: React.PropTypes.bool
+  absolute: React.PropTypes.bool,
+  onSetActive: React.PropTypes.func
 };
 
 var Helpers = {


### PR DESCRIPTION
Looks like `onSetActive` prop has been added in scope of https://github.com/fisshy/react-scroll/pull/28 to detect whenever `<Link>` is marked as active.

It has never been added to `propTypes` as well as documented.

This PR documents new prop in README.md as well as adds this `onSetActive` prop to propTypes so that it can be defined when creating a `<Link>`.