### PR TITLE
hotfix/set-container - fixed method setContainer in animate-scroll

### DIFF
--- a/build/npm/lib/mixins/animate-scroll.js
+++ b/build/npm/lib/mixins/animate-scroll.js
@@ -129,9 +129,8 @@ var setContainer = function (options) {
     __containerElement = null;
     return;
   }
-  if(!__containerElement) {
-	   __containerElement = document.getElementById(options.containerId);
-  }
+
+  __containerElement = document.getElementById(options.containerId);
 };
 
 var startAnimateTopScroll = function(y, options, to, target) {

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -129,9 +129,8 @@ var setContainer = function (options) {
     __containerElement = null;
     return;
   }
-  if(!__containerElement) {
-	   __containerElement = document.getElementById(options.containerId);
-  }
+
+  __containerElement = document.getElementById(options.containerId);
 };
 
 var startAnimateTopScroll = function(y, options, to, target) {


### PR DESCRIPTION
Hello. Sorry for my English.

Use your unit to scroll to the 
`<div id="container"><Element name="element"> content </Element></div>`
and 
`Scroll.scroller.scrollTo('element', {containerId: 'container'});`

There is a problem if we go for the first time, everything works fine, but if the walk on the site, and again go to the page, nothing happens. I found out it's because of what **__containerElement** has been announced, and the second time he has not appropriated. Accordingly, scroll to the item did not work.

See my solution to the problem, and accomplish your goal, what you think about it.

Thank you.