### PR TITLE
Spy doesn't work when new Links are mounted before an old one unmounts

### DIFF
--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -200,11 +200,19 @@ var Helpers = {
         name: React.PropTypes.string.isRequired
       },
       componentDidMount: function() {
-        var domNode = ReactDOM.findDOMNode(this);
-        defaultScroller.register(this.props.name, domNode);
+        this.registerElems(this.props.name);
+      },
+      componentWillReceiveProps: function(nextProps) {
+        if (this.props.name !== nextProps.name) {
+          this.registerElems(nextProps.name);
+        }
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+      },
+      registerElems: function(name) {
+        var domNode = ReactDOM.findDOMNode(this);
+        defaultScroller.register(name, domNode);
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -113,13 +113,15 @@ var Helpers = {
           var elemTopBound = 0;
           var elemBottomBound = 0;
 
-          scrollSpy.addStateHandler((function() {
+          this._stateHandler = function() {
             if(scroller.getActiveLink() != to) {
                 this.setState({ active : false });
             }
-          }).bind(this));
+          }.bind(this)
 
-          var spyHandler = function(y) {
+          scrollSpy.addStateHandler(this._stateHandler);
+
+          this._spyHandler = function(y) {
 
             var containerTop = 0;
             if(scrollSpyContainer.getBoundingClientRect) {
@@ -160,11 +162,11 @@ var Helpers = {
             }
           }.bind(this);
 
-          scrollSpy.addSpyHandler(spyHandler, scrollSpyContainer);
+          scrollSpy.addSpyHandler(this._spyHandler, scrollSpyContainer);
         }
       },
       componentWillUnmount: function() {
-        scrollSpy.unmount();
+        scrollSpy.unmount(this._stateHandler, this._spyHandler);
       },
       render: function() {
 

--- a/build/npm/lib/mixins/scroll-spy.js
+++ b/build/npm/lib/mixins/scroll-spy.js
@@ -76,11 +76,12 @@ var scrollSpy = {
     }
   },
 
-  unmount: function () {
+  unmount: function (stateHandler, spyHandler) {
     for (var i = 0; i < this.scrollSpyContainers.length; i++) {
-      this.scrollSpyContainers[i].spyCallbacks = [];
+      var callbacks = this.scrollSpyContainers[i].spyCallbacks;
+      callbacks.splice(callbacks.indexOf(spyHandler), 1);
     }
-    this.spySetState = [];
+    this.spySetState.splice(this.spySetState.indexOf(stateHandler), 1);
 
     document.removeEventListener('scroll', this.scrollHandler);
   },

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -200,11 +200,19 @@ var Helpers = {
         name: React.PropTypes.string.isRequired
       },
       componentDidMount: function() {
-        var domNode = ReactDOM.findDOMNode(this);
-        defaultScroller.register(this.props.name, domNode);
+        this.registerElems(this.props.name);
+      },
+      componentWillReceiveProps: function(nextProps) {
+        if (this.props.name !== nextProps.name) {
+          this.registerElems(nextProps.name);
+        }
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+      },
+      registerElems: function(name) {
+        var domNode = ReactDOM.findDOMNode(this);
+        defaultScroller.register(name, domNode);
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -113,13 +113,15 @@ var Helpers = {
           var elemTopBound = 0;
           var elemBottomBound = 0;
 
-          scrollSpy.addStateHandler((function() {
+          this._stateHandler = function() {
             if(scroller.getActiveLink() != to) {
                 this.setState({ active : false });
             }
-          }).bind(this));
+          }.bind(this)
 
-          var spyHandler = function(y) {
+          scrollSpy.addStateHandler(this._stateHandler);
+
+          this._spyHandler = function(y) {
 
             var containerTop = 0;
             if(scrollSpyContainer.getBoundingClientRect) {
@@ -160,11 +162,11 @@ var Helpers = {
             }
           }.bind(this);
 
-          scrollSpy.addSpyHandler(spyHandler, scrollSpyContainer);
+          scrollSpy.addSpyHandler(this._spyHandler, scrollSpyContainer);
         }
       },
       componentWillUnmount: function() {
-        scrollSpy.unmount();
+        scrollSpy.unmount(this._stateHandler, this._spyHandler);
       },
       render: function() {
 

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -76,11 +76,12 @@ var scrollSpy = {
     }
   },
 
-  unmount: function () {
+  unmount: function (stateHandler, spyHandler) {
     for (var i = 0; i < this.scrollSpyContainers.length; i++) {
-      this.scrollSpyContainers[i].spyCallbacks = [];
+      var callbacks = this.scrollSpyContainers[i].spyCallbacks;
+      callbacks.splice(callbacks.indexOf(spyHandler), 1);
     }
-    this.spySetState = [];
+    this.spySetState.splice(this.spySetState.indexOf(stateHandler), 1);
 
     document.removeEventListener('scroll', this.scrollHandler);
   },


### PR DESCRIPTION
In some cases I need to unmount some Links after the new page is displayed with the new Links.
The problem is that the "unmount" method (scroll-spy.js line 79) just removes all spyCallbacks from the scrollSpyContainers instead of removing the specific callback of the element that I try to unmount.