### PR TITLE
When an Element's name is changed, the element in not registered again

### DIFF
--- a/build/npm/lib/mixins/Helpers.js
+++ b/build/npm/lib/mixins/Helpers.js
@@ -198,11 +198,19 @@ var Helpers = {
         name: React.PropTypes.string.isRequired
       },
       componentDidMount: function() {
-        var domNode = ReactDOM.findDOMNode(this);
-        defaultScroller.register(this.props.name, domNode);
+        this.registerElems(this.props.name);
+      },
+      componentWillReceiveProps: function(nextProps) {
+        if (this.props.name !== nextProps.name) {
+          this.registerElems(nextProps.name);
+        }
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+      },
+      registerElems: function(name) {
+        var domNode = ReactDOM.findDOMNode(this);
+        defaultScroller.register(name, domNode);
       },
       render: function() {
         return React.createElement(Component, this.props);

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -198,11 +198,19 @@ var Helpers = {
         name: React.PropTypes.string.isRequired
       },
       componentDidMount: function() {
-        var domNode = ReactDOM.findDOMNode(this);
-        defaultScroller.register(this.props.name, domNode);
+        this.registerElems(this.props.name);
+      },
+      componentWillReceiveProps: function(nextProps) {
+        if (this.props.name !== nextProps.name) {
+          this.registerElems(nextProps.name);
+        }
       },
       componentWillUnmount: function() {
         defaultScroller.unregister(this.props.name);
+      },
+      registerElems: function(name) {
+        var domNode = ReactDOM.findDOMNode(this);
+        defaultScroller.register(name, domNode);
       },
       render: function() {
         return React.createElement(Component, this.props);


### PR DESCRIPTION
I need to change an `Element`'s name instead of destroying it and creating it again, but when I try to do this the `Element` is not registered again.
The solution that I found was to add a `componentWillReceiveProps` function to the `Element` in order to register it again when the name changes.