### PR TITLE
added check for mapping and presence of hash at start of name

### DIFF
--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -21,7 +21,16 @@ module.exports = {
   },
 
   get: function(name) {
-    return __mapped[name] || document.getElementById(name);
+
+    if(!__mapped[name]){
+
+      name = name.indexOf('#') === 0 ? name.slice(1, name.length) : name;
+
+      return document.getElementById(name);
+
+    }
+
+    return __mapped[name];
   },
 
   setActiveLink: function(link) {


### PR DESCRIPTION
When using elements with IDs across components using <div /> tags instead of <Element />, it was consistently throwing the error "target Element not found". This is due to the get call containing a name value with a hash, meaning the element would not be present when using document.getElementById. On thing I did notice is that if you are using <div /> tags, there is no way to register them.

This is a quick and verbose way of covering that error, which works locally for me. 
