### PR TITLE
setContainer in animate scroll before scrolling, problem occurs when …

### DIFF
--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -163,10 +163,12 @@ var startAnimateTopScroll = function(y, options, to, target) {
 };
 
 var scrollToTop = function (options) {
+  setContainer(options);
   startAnimateTopScroll(0, assign(options || {}, { absolute : true }));
 };
 
 var scrollTo = function (toY, options) {
+  setContainer(options);
   startAnimateTopScroll(toY, assign(options || {}, { absolute : true }));
 };
 


### PR DESCRIPTION
Related to #144 
Scroll container node remounts in the DOM but `animate-scroll` functions use previous container node, we should call `setContainer` before every `scrollTop()`