### PR TITLE
replace buggy custom throttler with lodash.throttle

### DIFF
--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,18 +1,5 @@
 var addPassiveEventListener = require('./passive-event-listeners');
-
-var eventThrottler = function(eventHandler) {
-  var eventHandlerTimeout;
-  return function(event) {
-    // ignore events as long as an eventHandler execution is in the queue
-    if ( !eventHandlerTimeout ) {
-      eventHandlerTimeout = setTimeout(function() {
-        eventHandlerTimeout = null;
-        eventHandler(event);
-        // The eventHandler will execute at a rate of 15fps
-      }, 66);
-    }
-  };
-};
+var throttle = require('lodash.throttle');
 
 var scrollSpy = {
 
@@ -23,9 +10,12 @@ var scrollSpy = {
   mount: function (scrollSpyContainer) {
     var t = this;
     if (scrollSpyContainer) {
-      var eventHandler = eventThrottler(function(event) {
+      // ignore events as long as an eventHandler execution is in the queue
+      // The eventHandler will execute at a rate of 15fps
+      var eventHandler = throttle(function(event) {
         t.scrollHandler(scrollSpyContainer);
-      });
+      }, 66);
+
       this.scrollSpyContainers.push(scrollSpyContainer);
       addPassiveEventListener(scrollSpyContainer, 'scroll', eventHandler);
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scrolls"
   ],
   "dependencies": {
+    "lodash.throttle": "^4.1.1",
     "object-assign": "^4.0.1",
     "react": "^15.0.1",
     "react-dom": "^15.0.1"


### PR DESCRIPTION
hello! i found some bugs in eventThrottler function (scroll-spy.js) when my events were fired incorrectly. i solve this problem with lodash.throttle function.
My own steps to reproduce:
→ enter to page with fixed menu (react-scroll.Link as items)
→ first time all works fine
→ leave the page
→ enter the page again and scroll
→ expected active links are not active and scrollHandler function not fired in 10-15 seconds