### PR TITLE
Fix `delay` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ React.render(
 
 > duration - time of the scroll animation
 
-> delay - wait x seconds before scroll
+> delay - wait x milliseconds before scroll
 
 > isDynamic - in case the distance has to be recalculated - if you have content that expands etc.
 


### PR DESCRIPTION
The value for the `delay` property represents milliseconds (not seconds).