### PR TITLE
add custom events listeners

### DIFF
--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -52,6 +52,12 @@ module.exports = {
         events.registered['begin'](to, target);
       }
 
+      Object.keys(events.registered).forEach(function(key) {
+        if (key !== 'begin' && key !== 'end') {
+          events.registered[key](to, target);
+        }
+      })
+
       var containerId = props.containerId;
       var containerElement = containerId ? document.getElementById(containerId) : null;
 


### PR DESCRIPTION
run functions registered under custom names which doesn't match with `begin` or `end`.

example: 

```
Events.scrollEvent.register('fn1', this.functionOne.bind(this));
Events.scrollEvent.register('fn2', this.functionTwo.bind(this));
```

this change address to the possibility to handle different instance of react-scroll in the same view or having multiple listeners which can be unsubscribed at different moments.