### PR TITLE
Move react and react-dom to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "scrolls"
   ],
   "dependencies": {
-    "object-assign": "^4.0.1",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "babel": "^5.8.23",
     "babel-core": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
     "mocha": "^2.3.3",
     "webpack": "^1.6.0",
     "webpack-dev-server": "^1.7.0"
+  },
+  "peerDependencies": {
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   }
 }


### PR DESCRIPTION
Make react and react-dom devDependencies so that installing react-scroll will not generate complaints about differing versions of react, or possibly fail altogether if using shrinkwrap.