### PR TITLE
Add ability to scroll to next `Element` using `__activeLink` as reference

### DIFF
--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -4,20 +4,25 @@ var animateScroll = require('./animate-scroll');
 var events = require('./scroll-events');
 
 var __mapped = {};
+var __links = [];
 var __activeLink;
 
 module.exports = {
 
   unmount: function() {
     __mapped = {};
+    __links = [];
   },
 
   register: function(name, element){
     __mapped[name] = element;
+    __links.push(name);
   },
 
   unregister: function(name) {
     delete __mapped[name];
+    var linkIndex = __links.indexOf(name);
+    __links = [].concat(__links.slice(0, linkIndex)).concat(__links.slice(linkIndex + 1));
   },
 
   get: function(name) {
@@ -30,6 +35,23 @@ module.exports = {
 
   getActiveLink: function() {
     return __activeLink;
+  },
+
+  getLinks: function () {
+    return __links;
+  },
+
+  getNextLink: function () {
+    var currentIndex = __links.indexOf(__activeLink) || 0;
+    var nextItem = __links[currentIndex + 1];
+    return nextItem;
+  },
+
+  scrollToNext: function (props) {
+    var to = this.getNextLink();
+    if (to) {
+      this.scrollTo(to, props);
+    }
   },
 
   scrollTo: function(to, props) {


### PR DESCRIPTION
Allows scrolling to the next `Scroll.Element` for dynamically generated `Scroll.Link`s and `Element`s by calling the following:

```js
const props = {smooth: true}
Scroll.scroller.scrollToNext(props)
```

Or to create a `scrollToNext` component as below

```js
class SrollToNext extends React.Component {
  scrollToNext = () => {
    const props = {smooth: true}
    Scroll.scroller.scrollToNext(props)
  }

  render () {
    return (
      <div>
        <div className='scroll-to-next' onClick={this.scrollToNext} />
        <Links /> // more info on `<Links />` below
      </div>
    )
  }
}
```
---

For `Scroll.scroller.scrollToNext` to work there must be `Scroll.Link`s for the `Scroll.Element`s with the `spy` prop set to true. If you are not using `Scroll.Link`s already as you do not want to display them then you could create them dynamically and hidden with a component such as the one below:

```js
class Links extends React.Component {
  state = {links: []}

  componentDidMount () {
    this.setState({links: Scroll.scroller.getLinks()})
  }

  onSetActive = (to) => {
    console.log('scrolled to', to)
  }

  settings = (to) => ({
    onSetActive: this.onSetActive,
    style: {display: 'none'},
    isDynamic: true,
    spy: true,
    to: to
  })

  render () {
    return (
      <div>
        {this.state.links.map(link => (
          <Scroll.Link key={link} {...this.settings(link)} />
        ))}
      </div>
    )
  }
}
```