### PR TITLE
Add containerId to the README example of ScrollTo Element function

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ scroller.scrollTo('myScrollToElement', {
   duration: 1500,
   delay: 100,
   smooth: true,
+  containerId: 'ContainerElementID',
+  ...
 })
 
 ```


### PR DESCRIPTION
Added containerId prop to the scrollTo example for clearer documentation (wasted some time on it myself before I read the source code and realized what I should do :( )

I know this is part of the Link props and should be obvious, but apparently it isn't that obvious...