### PR TITLE
Fix the error related with absolute path

### DIFF
--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
   }, {}),
 
   output: {
-    path: 'examples/__build__',
+    path: path.resolve(__dirname, '__build__'),
     filename: '[name].js',
     chunkFilename: '[id].chunk.js',
     publicPath: '/__build__/'
@@ -43,7 +43,7 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.optimize.CommonsChunkPlugin('shared.js'),
+    new webpack.optimize.CommonsChunkPlugin('shared'),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
     })


### PR DESCRIPTION
Fix the error with build script:
"
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "examples/build" is not an absolute path!
"