### PR TITLE
Use JSX instead of React DOM factories to fix React warning in >= 15.6

### DIFF
--- a/modules/components/Button.js
+++ b/modules/components/Button.js
@@ -5,7 +5,11 @@ var Helpers = require('../mixins/Helpers');
 
 class Button extends React.Component{
   render() {
-    return React.DOM.input(this.props, this.props.children);
+    return (
+      <input {...this.props}>
+        {this.props.children}
+      </input>
+    );
   }
 };
 

--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -5,7 +5,11 @@ var Helpers = require('../mixins/Helpers');
 
 class Element extends React.Component{
   render() {
-    return React.DOM.div(this.props, this.props.children);
+    return (
+      <div {...this.props}>
+        {this.props.children}
+      </div>
+    );
   }
 };
 

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -5,7 +5,11 @@ var Helpers = require('../mixins/Helpers');
 
 class Link extends React.Component{
   render() {
-    return React.DOM.a(this.props, this.props.children);
+    return (
+      <a {...this.props}>
+        {this.props.children}
+      </a>
+    );
   }
 };
 


### PR DESCRIPTION
Fixes the following warning in React 15.6 and above:

“Warning: Accessing factories like React.DOM.a has been deprecated and will be removed in v16.0+. Use the react-dom-factories package instead.  Version 1.0 provides a drop-in replacement. For more info, see https://fb.me/react-dom-factories”