### PR TITLE
Added 'container' prop to allow for node to be used

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -13,6 +13,7 @@ var PropTypes = require('prop-types');
 var protoTypes = {
   to: PropTypes.string.isRequired,
   containerId: PropTypes.string,
+  container: PropTypes.object,
   activeClass:PropTypes.string,
   spy: PropTypes.bool,
   smooth: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
@@ -106,8 +107,9 @@ var Helpers = {
       componentDidMount() {
 
         var containerId = this.props.containerId;
+		var container = this.props.container;
 
-        var scrollSpyContainer = containerId ? document.getElementById(containerId) : document;
+        var scrollSpyContainer = containerId ? document.getElementById(containerId) : (container && container.nodeType) ? container : document;
 
         if(!scrollSpy.isMounted(scrollSpyContainer)) {
           scrollSpy.mount(scrollSpyContainer);

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -163,12 +163,12 @@ var animateTopScroll = function(easing, timestamp) {
 };
 
 var setContainer = function (options) {
-  if(!options || !options.containerId) {
+  if(!options || (!options.containerId && !options.container && !options.container.nodeType)) {
     __containerElement = null;
     return;
   }
 
-  __containerElement = document.getElementById(options.containerId);
+  __containerElement = options.containerId ? document.getElementById(options.containerId) : options.container;
 };
 
 var startAnimateTopScroll = function(y, options, to, target) {

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -53,17 +53,19 @@ module.exports = {
       }
 
       var containerId = props.containerId;
-      var containerElement = containerId ? document.getElementById(containerId) : null;
+	  var container = props.container;
+	  
+      var containerElement = containerId ? document.getElementById(containerId) : (container && container.nodeType) ? container : null;
 
       var scrollOffset;
 
-      if(containerId && containerElement) {
+      if((containerId || container) && containerElement) {
         props.absolute = true;
         if(containerElement !== target.offsetParent) {
           if(!containerElement.contains(target)) {
-            throw new Error('Container with ID ' + containerId + ' is not a parent of target ' + to);
+            throw new Error('Container with ID ' + (containerId  || container) + ' is not a parent of target ' + to);
           } else {
-            throw new Error('Container with ID ' + containerId + ' is not a positioned element');
+            throw new Error('Container with ID ' + (containerId  || container)  + ' is not a positioned element');
           }
         }
 
@@ -80,7 +82,7 @@ module.exports = {
        * if animate is not provided just scroll into the view
        */
       if(!props.smooth) {
-        if(containerId && containerElement) {
+        if((containerId  || container) && containerElement) {
           containerElement.scrollTop = scrollOffset;
         } else {
           // window.scrollTo accepts only absolute values so body rectangle needs to be subtracted


### PR DESCRIPTION
Had requirement to pass node as cotainter not just ID. If both 'containerId' and 'container' props are passed, the former takes precedence