### PR TITLE
[Change] Use `rel` instead of `findDOMNode`

### DIFF
--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -5,8 +5,14 @@ var Helpers = require('../mixins/Helpers');
 
 class Element extends React.Component{
   render() {
+    // Remove `parentBindings` from props
+    let newProps = Object.assign({}, this.props);
+    if (newProps.parentBindings) {
+      delete newProps.parentBindings;
+    }
+
     return (
-      <div {...this.props} ref={(el) => { this.props.parentBindings.domNode = el; }}>
+      <div {...newProps} ref={(el) => { this.props.parentBindings.domNode = el; }}>
         {this.props.children}
       </div>
     );

--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -6,7 +6,7 @@ var Helpers = require('../mixins/Helpers');
 class Element extends React.Component{
   render() {
     return (
-      <div {...this.props}>
+      <div {...this.props} ref={(el) => { this.props.parentBindings.domNode = el; }}>
         {this.props.children}
       </div>
     );

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -228,6 +228,9 @@ var Helpers = {
       constructor (props){
         super(props);
         this.registerElems = this.registerElems.bind(this);
+        this.childBindings = {
+          domNode: null
+        };
       }
 
       componentDidMount() {
@@ -242,11 +245,10 @@ var Helpers = {
         defaultScroller.unregister(this.props.name);
       }
       registerElems(name) {
-        var domNode = ReactDOM.findDOMNode(this);
-        defaultScroller.register(name, domNode);
+        defaultScroller.register(name, this.childBindings.domNode);
       }
       render() {
-        return React.createElement(Component, this.props);
+        return React.createElement(Component, Object.assign({}, this.props, { parentBindings: this.childBindings }));
       }
     };
     _.propTypes = {


### PR DESCRIPTION
This allows for testing with jsdom and jest

See: https://github.com/fisshy/react-scroll/issues/185


Another way to solve this is using `bindNode` (the way this person did: https://github.com/Baransu/react-scroll/commit/5f1708a7dbe0586500c67df1241344c32bb8dd9c)