### PR TITLE
feat(element): Add support for user-declared Element tagName

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ React.render(
 
 > ignoreCancelEvents - ignores events which cancel animated scrolling
 
+> tagName - specify the underlying HTML element to constitute the `Element` component
+
 ```js
 <Link activeClass="active"
       to="target"

--- a/examples/basic/app.css
+++ b/examples/basic/app.css
@@ -6,11 +6,15 @@
 	height:1000px;
 	background-color: #ededed;
 	font-size: 45px;
-	border-top:1px solid #000;
-	padding-top:55px;
-	padding-left:10px;
+	border-top: 1px solid #000;
+	padding-top: 55px;
+	padding-left: 10px;
 }
 
 .active {
 	color:red !important;
+}
+
+.nav > li {
+  cursor: pointer;
 }

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -55,6 +55,7 @@ class Section extends React.Component{
                 <li><Link activeClass="active" className="test4" to="test4" spy={true} smooth={true} duration={500}>Test 4</Link></li>
                 <li><Link activeClass="active" className="test5" to="test5" spy={true} smooth={true} duration={500} delay={1000}>Test 5 ( delay )</Link></li>
                 <li><Link activeClass="active" className="test6" to="anchor" spy={true} smooth={true} duration={500}>Test 6 (anchor)</Link></li>
+                <li><Link activeClass="active" className="customTagName" to="customTagName" spy={true} smooth={true} duration={500}>Custom Tag</Link></li>
                 <li><Link activeClass="active" className="test7" to="test7" spy={true} smooth={true} duration={durationFn}>Test 7 (duration and container)</Link></li>
                 <li> <a onClick={() => scroll.scrollTo(100)}>Scroll To 100!</a></li>
                 <li> <a onClick={() => scroll.scrollToBottom()}>Scroll To Bottom</a></li>
@@ -67,7 +68,7 @@ class Section extends React.Component{
           </div>
         </nav>
 
-        <Element name="test1" className="element" >
+        <Element name="test1" className="element">
           test 1
         </Element>
 
@@ -90,6 +91,10 @@ class Section extends React.Component{
         <div id="anchor" className="element">
           test 6 (anchor)
         </div>
+
+        <Element name="customTagName" className="element" tagName="H1">
+          Custom &lt;h1&gt; tagName
+        </Element>
 
         <Link activeClass="active" to="firstInsideContainer" spy={true} smooth={true} duration={250} containerId="containerElement" style={{display:'inline-block', margin: '20px'}}>
           Go to first element inside container

--- a/modules/components/Element.js
+++ b/modules/components/Element.js
@@ -2,21 +2,58 @@
 
 var React = require('react');
 var Helpers = require('../mixins/Helpers');
+var PropTypes = require('prop-types');
 
-class Element extends React.Component{
+class Element extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
   render() {
-    // Remove `parentBindings` from props
-    let newProps = Object.assign({}, this.props);
-    if (newProps.parentBindings) {
-      delete newProps.parentBindings;
+    const {
+      children,
+      tagName = 'DIV',
+      parentBindings,
+      ...rest
+    } = this.props;
+
+    const passedProps = {
+      ...rest,
+      ref: (el) => { parentBindings.domNode = el; }
+    };
+
+    return (React.createElement(tagName, passedProps, children));
+  }
+};
+
+Element.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  tagName: (props, propName, componentName) => {
+    const obsoleteTags = ['BASEFONT', 'BGSOUND', 'FRAME', 'ISINDEX'];
+    const selfClosingTags = [
+      'AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT',
+      'KEYGEN', 'LINK', 'MENUITEM', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'
+    ];
+
+    if (typeof props[propName] !== 'string') {
+      return new TypeError(
+        `Prop ${propName} in ${componentName} of type ${typeof props[propName]}. Expected string.`
+      );
     }
 
-    return (
-      <div {...newProps} ref={(el) => { this.props.parentBindings.domNode = el; }}>
-        {this.props.children}
-      </div>
-    );
-  }
+    if (selfClosingTags.concat(obsoleteTags).includes(props[propName].toUpperCase())) {
+      return new Error(
+        `Prop ${propName} passed to the ${componentName} component may not be a self-closing HTML tagName.`
+      );
+    }
+  },
+};
+
+Element.defaultProps = {
+  tagName: 'DIV',
 };
 
 module.exports = Helpers.Element(Element);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scroll",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "dependencies": {
     "accepts": {
@@ -304,6 +304,11 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
@@ -442,6 +447,11 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true
     },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE="
+    },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
@@ -528,13 +538,11 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true,
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-          "dev": true
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
         }
       }
     },
@@ -4139,8 +4147,7 @@
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.9.11",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "scrolls"
   ],
   "dependencies": {
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "object-assign": "^4.1.1",
     "prop-types": "^15.5.8"
   },
@@ -66,6 +67,9 @@
     "presets": [
       "es2015",
       "react"
+    ],
+    "plugins": [
+      "transform-object-rest-spread"
     ]
   },
   "directories": {


### PR DESCRIPTION
+ Recompose the existing `<Element />` React component to expose React's `createElement()` method, thereby allowing user-specified declaration of its underlying HTML element.
  + The HTML element defaults to a `<div>` when no `tagName` prop is passed.
  + While there isn't so much an explicit _need_ for this feature, it is a beneficial inclusion inasmuch as browsers have become progressively more picky _re_: semantic pages.
  + Dynamically setting the HTML `tagName` allows for a more neatly structured and consistent DOM tree in certain scenarios and it is such situations that this PR aims to address
+ Include brief description documenting new  prop usage in README
+ Ensure links in the examples have 'pointer' CSS cursor value
+ Integrate the ES7 object-rest-spread Babel transformation plugin
+ Add an additional example for custom tagName