### PR TITLE
fix: typos in getAnimationType

### DIFF
--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -10,41 +10,7 @@ var events = require('./scroll-events');
  * Gets the easing type from the smooth prop within options.
  */
 var getAnimationType = function (options) {
-  if (typeof options.smooth === Boolean && options.smooth === true) {
-    return smooth.defaultEasing;
-  } else {
-    var animationType = options.smooth;
-    switch (animationType) {
-      case "linear":
-        return smooth.linear;
-      case "easeInQuad":
-        return smooth.easeInQuad;
-      case "easeOutQuad":
-        return smooth.easeOutQuad;
-      case "easeInOutQuad":
-        return smooth.easeInOutQuad;
-      case "easeInCubic":
-        return smooth.easeInCubic;
-      case "easeOutCubic":
-        return smooth.easeOutQuad;
-      case "easeInOutCubic":
-        return smooth.easeInQuad;
-      case "easeInQuart":
-        return smooth.easeInQuart;
-      case "easeOutQuart":
-        return smooth.easeOutQuart;
-      case "easeInOutQuart":
-        return smooth.easeInOutQuart;
-      case "easeInQuint":
-        return smooth.easeInQuint;
-      case "easeOutQuint":
-        return smooth.easeInQuint;
-      case "easeInOutQuint":
-        return smooth.easeInOutQuint;
-      default:
-        return smooth.defaultEasing;
-    }
-  }
+  return smooth[options.smooth] || smooth.defaultEasing;
 };
 
 /*


### PR DESCRIPTION
There are typos in `getAnimationType` that cause the wrong easing to be selected.

The existing code had been mapping from `options.smooth` to the appropriate easing function from `smooth.js`. The problem is that some of the mappings were incorrect.

My proposed solution is to do a simple lookup directly on the object exported from `smooth.js`. This reduces code, and increases maintainability by creating one source of truth for the smooth options.

The new code should behave equivalently to the old with one slight exception: `'defaultEasing'` can now be passed to access that easing directly. This shouldn't have much effect since passing `'defaultEasing'` before (or even `'foobar'`) would have still resulted in `defaultEasing` being used. The only concern is that now people might come to expect `'defaultEasing'` to work, even if it's not a documented option.