### PR TITLE
Simplify scroll event cancellation

### DIFF
--- a/modules/__tests__/scroll-cancellation-test.js
+++ b/modules/__tests__/scroll-cancellation-test.js
@@ -1,0 +1,67 @@
+/* React */
+import { render, unmountComponentAtNode, findDOMNode } from 'react-dom'
+import Rtu      from 'react-dom/test-utils'
+import React    from 'react'
+import expect   from 'expect'
+import assert   from 'assert';
+import scroll from '../mixins/animate-scroll.js';
+
+describe('scroll cancellation', () => {
+  let node = document.createElement('div');
+  document.body.innerHtml = "";
+
+  document.body.appendChild(node)
+
+  beforeEach(function () {
+    unmountComponentAtNode(node);
+    window.scrollTo(0,0);
+  });
+
+  describe("when scrolling is triggered by keydown handlers", () => {
+    it("can scroll on keydown multiple times in a row", async () => {
+      const duration = 100;
+      const distance = 100;
+
+      class TestComponent extends React.Component {
+        handleKeyDown = () => {
+          scroll.scrollMore(distance, { smooth: true, duration });
+        }
+        render () {
+          return (
+            <div>
+              <input onKeyDown={this.handleKeyDown} />
+              <div style={{height: "3000px", width: "100%", background: "repeating-linear-gradient(to bottom, white, black 100px)"}}/>
+            </div>
+          );
+        }
+      }
+
+      render(<TestComponent/>, node);
+
+      dispatchDOMKeydownEvent(13, node.querySelector('input'));
+      await wait(duration*2);
+      expect(window.scrollY).toBeGreaterThanOrEqualTo(distance);
+
+      dispatchDOMKeydownEvent(13, node.querySelector('input'));
+      await wait(duration*2);
+      expect(window.scrollY).toBeGreaterThanOrEqualTo(distance * 2);
+
+      dispatchDOMKeydownEvent(13, node.querySelector('input'));
+      await wait(duration*2);
+      expect(window.scrollY).toBeGreaterThanOrEqualTo(distance * 3);
+    });
+  });
+});
+
+function wait(ms) {
+  return new Promise((res, rej) => {
+    setTimeout(res, ms);
+  })
+}
+
+function dispatchDOMKeydownEvent(keyCode, element) {
+  const event = document.createEvent("KeyboardEvent");
+  const initMethod = typeof event.initKeyboardEvent !== 'undefined' ? "initKeyboardEvent" : "initKeyEvent";
+  event[initMethod]("keydown", true, true, window, 0, 0, 0, 0, 0, keyCode);
+  element.dispatchEvent(event);
+}

--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -53,6 +53,10 @@ let __deltaTop;
 let __percent;
 let __delayTimeout;
 
+cancelEvents.subscribe(() => {
+  __cancel = true;
+});
+
 const currentPositionY = () => {
   if (__containerElement && __containerElement !== document && __containerElement !== document.body) {
     return __containerElement.scrollTop;
@@ -85,26 +89,13 @@ const scrollContainerHeight = () => {
   }
 };
 
-const subscribeCancelEvents = (options) => {
-  if (!options.ignoreCancelEvents) {
-    cancelEvents.subscribe(cancelListener);
-  }
-}
-
-const unsubscribeCancelEvents = (options) => {
-  if (!options.ignoreCancelEvents) {
-    cancelEvents.unsubscribe(cancelListener);
-  }
-}
-
 const animateScroll = (easing, options, timestamp) => {
 
   // Cancel on specific events
-  if (__cancel) {
+  if (!options.ignoreCancelEvents && __cancel) {
     if (events.registered['end']) {
       events.registered['end'](__to, __target, __currentPositionY);
     }
-    unsubscribeCancelEvents(options);
     return
   };
 
@@ -134,7 +125,6 @@ const animateScroll = (easing, options, timestamp) => {
 
   if (events.registered['end']) {
     events.registered['end'](__to, __target, __currentPositionY);
-    unsubscribeCancelEvents(options);
   }
 
 };
@@ -151,16 +141,10 @@ const setContainer = (options) => {
           : document;
 };
 
-const cancelListener = () => {
-  __cancel = true;
-}
-
 const animateTopScroll = (y, options, to, target) => {
 
   window.clearTimeout(__delayTimeout);
 
-  subscribeCancelEvents(options);
-  
   setContainer(options);
 
   __start = null;

--- a/modules/mixins/cancel-events.js
+++ b/modules/mixins/cancel-events.js
@@ -3,5 +3,4 @@ const events = ['mousedown', 'mousewheel', 'touchmove', 'keydown']
 
 module.exports = {
   subscribe : (cancelEvent) => (typeof document !== 'undefined') && events.forEach(event => addPassiveEventListener(document, event, cancelEvent)),
-  unsubscribe : (cancelEvent) => (typeof document !== 'undefined') && events.forEach(event => removePassiveEventListener(document, event, cancelEvent))
 };


### PR DESCRIPTION
Fixes #269 

The first commit dea9cb3 is the failing test that describes the issue in #269. For some reason, it only fails (as it should) when run alone via `describe.only`; it somehow passes when run with the rest of the tests. I suspect there is some poor test isolation going on with the rest of the test suites; maybe a test suite is mutating some top level variables without cleaning up...

The second commit b7741ad is the fix. We simply bind the event listener once, during module initialization time, instead of binding new event listeners every scroll invocation.