### PR TITLE
Change scroller.js exported name

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -1,7 +1,7 @@
 export { default as Link }  from './components/Link.js';
 export { default as Button }  from './components/Button.js';
 export { default as Element }  from './components/Element.js';
-export { default as scroll } from './mixins/scroller.js';
+export { default as scroller } from './mixins/scroller.js';
 export { default as Events } from './mixins/scroll-events.js';
 export { default as scrollSpy } from './mixins/scroll-spy.js';
 export { default as animateScroll } from './mixins/animate-scroll.js';


### PR DESCRIPTION
Before, a scroller.js was exported as a "scroller", but now it's imported as a "scroll" and it breaks all of the old code.