### PR TITLE
Prevent re-rendering all links on every scroll tick

### DIFF
--- a/modules/mixins/scroll-link.js
+++ b/modules/mixins/scroll-link.js
@@ -30,7 +30,7 @@ export default (Component, customScroller) => {
 
   const scroller = customScroller || defaultScroller;
 
-  class Link extends React.Component {
+  class Link extends React.PureComponent {
     constructor(props) {
       super(props);
       this.state = {


### PR DESCRIPTION
Currently when scrolling with `spy` enabled, all links are constantly re-rendered instead of just the ones whose `active` state is changing. This PR fixes that by making `ScrollLink` a `PureComponent`. The following animations show which links are being re-rendered.

Before:
![before](https://user-images.githubusercontent.com/128019/34368045-78544080-ea76-11e7-95b7-7f7fb30f0187.gif)

After:
![after](https://user-images.githubusercontent.com/128019/34368047-7bbda9dc-ea76-11e7-8c32-134b62ce3db4.gif)
