### PR TITLE
Refer to the element by className

### DIFF
--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -19,7 +19,7 @@ export default {
     delete __mapped[name];
   },
 
-  get: (name) => __mapped[name] || document.getElementById(name) || document.getElementsByName(name)[0],
+  get: (name) => __mapped[name] || document.getElementById(name) || document.getElementsByName(name)[0] || document.getElementsByClassName(name)[0],
 
   setActiveLink: (link) => __activeLink = link,
 


### PR DESCRIPTION
It can be useful when we have few elements and need to scroll to first of them. Right now as I know, `react-scroll` can't handle this situation except elements with the name attribute (so it can be one of the form elements) or by handling complex logic on the client side to keep tracking of multiple ids of elements.