### PR TITLE
Use lodash throttle

### DIFF
--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,18 +1,8 @@
+import throttle from "lodash.throttle";
 import { addPassiveEventListener } from './passive-event-listeners';
 
-const eventThrottler = (eventHandler)  => {
-  let eventHandlerTimeout;
-  return (event) => {
-    // ignore events as long as an eventHandler execution is in the queue
-    if ( !eventHandlerTimeout ) {
-      eventHandlerTimeout = setTimeout(() => {
-        eventHandlerTimeout = null;
-        eventHandler(event);
-        // The eventHandler will execute at a rate of 15fps
-      }, 66);
-    }
-  };
-};
+// The eventHandler will execute at a rate of 15fps
+const eventThrottler = (eventHandler)  => throttle(eventHandler, 66);
 
 const scrollSpy = {
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "scrolls"
   ],
   "dependencies": {
+    "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Change eventThrottler to use lodash throttle instead of custom throttle
implementation to fix issues with performance degradation when adding
more elements and links in the same browser session.

Fixes #308