### PR TITLE
fixed calculation position top for element

### DIFF
--- a/modules/mixins/utils.js
+++ b/modules/mixins/utils.js
@@ -23,7 +23,7 @@ const  getHash = () => {
 const filterElementInContainer = (container) => (element) => container.contains ? container != element && container.contains(element) : !!(container.compareDocumentPosition(element) & 16)
 
 const scrollOffset = (c, t) => c === document ? 
-      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position === "relative" ? t.offsetTop : (t.offsetTop - c.offsetTop)
+      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position === "relative" ? t.offsetTop : (t.getBoundingClientRect().top + c.scrollTop)
 
 export default {
   pushHash,


### PR DESCRIPTION
fixed position calculation top for element when container position is set fixed.

offsetTop is deprecated parameter and counting relative to the parent.
getBoundingClientRect().top finds the correct distance from the top of the screen.
So the element can be nested deeply and it will work correctly.