### PR TITLE
setting active class on visible Element

### DIFF
--- a/modules/mixins/scroll-link.js
+++ b/modules/mixins/scroll-link.js
@@ -110,6 +110,7 @@ export default (Component, customScroller) => {
 
         if (this.props.spy && this.state.active) {
           this.setState({ active: false });
+          element.classList.remove(this.getActiveClassName());
           this.props.onSetInactive && this.props.onSetInactive(to, element);
         }
 
@@ -122,6 +123,7 @@ export default (Component, customScroller) => {
 
         if (this.props.spy) {
           this.setState({ active: true });
+          element.classList.add(this.getActiveClassName());
           this.props.onSetActive && this.props.onSetActive(to, element);
         }
       }
@@ -140,6 +142,10 @@ export default (Component, customScroller) => {
       }
 
       return document;
+    }
+
+    getActiveClassName() {
+      return this.props.activeClass || "active";
     }
 
     componentDidMount() {


### PR DESCRIPTION
This will come in handy when a user wants to visually distinguish between the active and inactive **Element**(s) . He/She can customize it by providing the styles for the _activeClass_ .