### PR TITLE
Fix for wrong activeLink when component remounts

### DIFF
--- a/modules/mixins/scroll-link.js
+++ b/modules/mixins/scroll-link.js
@@ -115,7 +115,7 @@ export default (Component, customScroller) => {
 
       }
 
-      if (isInside && activeLink !== to) {
+      if (isInside && (activeLink !== to || this.state.active === false)) {
         scroller.setActiveLink(to);
 
         this.props.hashSpy && scrollHash.changeHash(to);


### PR DESCRIPTION
First of all, thanks for the amazing library!

There is a bug, that when a active component gets unmounted and mounted
again, the state won't be set to active, due to wrong caching.

Repro: 
1. https://codesandbox.io/s/yv372noqjv
2. "Go to first element inside container" is active
3. click on button "Show / Hide" to unmount the component
4. click on button "Show / Hide" to mount the component
5. "Go to first element inside container" not active anymore

In this demo you can see the fixed version.
https://codesandbox.io/s/qkjj5z8wq

Cheers
Thomas