### PR TITLE
Fix to use offsetTop of absolute positioned container element

### DIFF
--- a/modules/mixins/utils.js
+++ b/modules/mixins/utils.js
@@ -22,8 +22,8 @@ const  getHash = () => {
 
 const filterElementInContainer = (container) => (element) => container.contains ? container != element && container.contains(element) : !!(container.compareDocumentPosition(element) & 16)
 
-const scrollOffset = (c, t) => c === document ? 
-      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position === "relative" ? t.offsetTop : (t.getBoundingClientRect().top + c.scrollTop)
+const scrollOffset = (c, t) => c === document ?
+      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position !== "static" ? t.offsetTop : (t.getBoundingClientRect().top + c.scrollTop)
 
 export default {
   pushHash,


### PR DESCRIPTION
Hello,

I had been suffered from scroll offset error, and I've finally found `scrollOffset` function in `modules/mixins/utils.js` is not working properly when container is absolute positioned element.

I'm actually using [react-custom-scrollbars](https://github.com/malte-wessel/react-custom-scrollbars) to customize scrollbars, and it makes container element as an absolute positioned element. Because the computed `position` property of the container element is not `relative` but `absolute`, scroller changes `scrollTop` to wrong position.

I tried to change 26th line of `modules/mixins/utils.js` from

```javascript
      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position === "relative" ? t.offsetTop : (t.getBoundingClientRect().top + c.scrollTop)
```

to

```javascript
      t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset) : getComputedStyle(c).position !== "static" ? t.offsetTop : (t.getBoundingClientRect().top + c.scrollTop)
```

and all of my problem is gone.

** In addition, I also tested this changes for fixed positioned container element, it worked properly.