### PR TITLE
create a separate .babelrc file and add it to .npmignore

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "es2015",
+    "react"
+  ],
+  "plugins": [
+    "transform-object-assign"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/package.json
+++ b/package.json
@@ -69,15 +69,6 @@
     "react": "^15.5.4 || ^16.0.0",
     "react-dom": "^15.5.4 || ^16.0.0"
   },
-  "babel": {
-    "presets": [
-      "es2015",
-      "react"
-    ],
-    "plugins": [
-      "transform-object-assign"
-    ]
-  },
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
babel applies whatever config is closest to any given source file, meaning a .babelrc (or babel config in package.json) provided by this NPM package will overrule a .babelrc belonging to consumers of this package who may require different presets and plugins for their app.