### PR TITLE
Fix recalculation coordinates of element every time when spy handler is invoked

### DIFF
--- a/modules/mixins/scroll-link.js
+++ b/modules/mixins/scroll-link.js
@@ -31,6 +31,12 @@ export default (Component, customScroller) => {
   const scroller = customScroller || defaultScroller;
 
   class Link extends React.PureComponent {
+    element = null;
+    elementBounds = {
+      topBound: 0,
+      bottomBound: 0,
+    }
+
     constructor(props) {
       super(props);
       this.state = {
@@ -75,9 +81,9 @@ export default (Component, customScroller) => {
       }
 
       let to = this.props.to;
-      let element = null;
-      let elemTopBound = 0;
-      let elemBottomBound = 0;
+      let element = this.element;
+      let elemTopBound = this.elementBounds.topBound;
+      let elemBottomBound = this.elementBounds.bottomBound;
       let containerTop = 0;
 
       if (scrollSpyContainer.getBoundingClientRect) {
@@ -92,6 +98,12 @@ export default (Component, customScroller) => {
         let cords = element.getBoundingClientRect();
         elemTopBound = (cords.top - containerTop + y);
         elemBottomBound = elemTopBound + cords.height;
+
+        this.element = element
+        this.elementBounds = {
+          topBound: elemTopBound,
+          bottomBound: elemBottomBound
+        }
       }
 
       let offsetY = y - this.props.offset;


### PR DESCRIPTION
Recalculation coordinates must happen every time only if isDynamic prop is passed! But recalculation has happened every time regardless of isDynamic prop.