### PR TITLE
Renamed deprecated react lifecycles to UNSAFE_*

### DIFF
--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -241,7 +241,7 @@ const Helpers = {
         }
         this.registerElems(this.props.name);
       }
-      componentWillReceiveProps(nextProps) {
+      UNSAFE_componentWillReceiveProps(nextProps) {
         if (this.props.name !== nextProps.name) {
           this.registerElems(nextProps.name);
         }

--- a/modules/mixins/scroll-element.js
+++ b/modules/mixins/scroll-element.js
@@ -20,7 +20,7 @@ export default (Component) => {
         }
         this.registerElems(this.props.name);
       }
-      componentWillReceiveProps(nextProps) {
+      UNSAFE_componentWillReceiveProps(nextProps) {
         if (this.props.name !== nextProps.name) {
           this.registerElems(nextProps.name);
         }


### PR DESCRIPTION
With the latest version of react (16.9.0), a warning is being displayed whenever a deprecated lifecycle method is used. This PR is a quick fix which renames the lifecycle into UNSAFE_* which is still supported by react. This will remove the warnings but not totally fix the deprecated lifecycles. This is a stop-gap solution.