### PR TITLE
Ensure 'begin' event fires on all scroll events

### DIFF
--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -163,11 +163,17 @@ const animateTopScroll = (y, options, to, target) => {
 
   if (options && options.delay > 0) {
     options.data.delayTimeout = window.setTimeout(() => {
+      if (events.registered['begin']) {
+        events.registered['begin'](options.data.to, options.data.target);
+      }
       requestAnimationFrameHelper.call(window, easedAnimate);
     }, options.delay);
     return;
   }
 
+  if (events.registered['begin']) {
+    events.registered['begin'](options.data.to, options.data.target);
+  }
   requestAnimationFrameHelper.call(window, easedAnimate);
 
 };

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -56,6 +56,10 @@ export default {
        * if animate is not provided just scroll into the view
        */
       if(!props.smooth) {
+        if(events.registered['begin']) {
+          events.registered['begin'](to, target);
+        }
+
         if (containerElement === document) {
           window.scrollTo(0, scrollOffset);
         } else {

--- a/modules/mixins/scroller.js
+++ b/modules/mixins/scroller.js
@@ -1,6 +1,6 @@
 import utils  from './utils';
 import animateScroll from './animate-scroll';
-import events from'./scroll-events';
+import events from './scroll-events';
 
 let __mapped = {}
 let __activeLink;
@@ -46,10 +46,6 @@ export default {
         containerElement = container;
       } else {
         containerElement = document;
-      }
-
-      if(events.registered.begin) {
-        events.registered.begin(to, target);
       }
 
       props.absolute = true;


### PR DESCRIPTION
Currently react-scroll's `animateScroll` only has an implementation for the `end` event. Here we add the `begin` event to `animateScroll` and and relocate the implementation within `scroller` to avoid duplicate calls.

This aims to solve the issue mentioned in #327 & #391