### PR TITLE
Update peer dependencies for react 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "webpack-dev-server": "^2.11.5"
   },
   "peerDependencies": {
-    "react": "^15.5.4 || ^16.0.0",
-    "react-dom": "^15.5.4 || ^16.0.0"
+    "react": "^15.5.4 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Otherwise we get this error when running `npm install` using React 17.x:

```
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^15.5.4 || ^16.0.0" from react-scroll@1.8.1
npm ERR! node_modules/react-scroll
npm ERR!   react-scroll@"^1.8.1" from the root project
```