### PR TITLE
fixing scrollOffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ $ npm start
 ```js
 // ES6 Imports
 import * as Scroll from 'react-scroll';
-import { Link, Element, Events, animateScroll as scroll, scrollSpy, scroller } from 'react-scroll'
+import { Link, Button, Element, Events, animateScroll as scroll, scrollSpy, scroller } from 'react-scroll'
 
 // Or Access Link,Element,etc as follows
 let Link      = Scroll.Link;
+let Button    = Scroll.Button;
 let Element   = Scroll.Element;
 let Events    = Scroll.Events;
 let scroll    = Scroll.animateScroll;
@@ -57,6 +58,7 @@ var React  = require('react');
 var Scroll = require('react-scroll');
 
 var Link      = Scroll.Link;
+var Button    = Scroll.Button;
 var Element   = Scroll.Element;
 var Events    = Scroll.Events;
 var scroll    = Scroll.animateScroll;

--- a/modules/mixins/utils.js
+++ b/modules/mixins/utils.js
@@ -19,6 +19,21 @@ const filterElementInContainer = (container) => (element) =>
     ? container != element && container.contains(element)
     : !!(container.compareDocumentPosition(element) & 16);
 
+const isPositioned = (element) =>
+  getComputedStyle(element).position !== "static";
+
+const getElementOffsetInfoUntil = (element, predicate) => {
+  let offsetTop = element.offsetTop;
+  let currentOffsetParent = element.offsetParent;
+
+  while (currentOffsetParent && !predicate(currentOffsetParent)) {
+    offsetTop += currentOffsetParent.offsetTop;
+    currentOffsetParent = currentOffsetParent.offsetParent;
+  }
+
+  return { offsetTop, offsetParent: currentOffsetParent };
+};
+
 const scrollOffset = (c, t, horizontal) => {
   if (horizontal) {
     return c === document
@@ -33,21 +48,63 @@ const scrollOffset = (c, t, horizontal) => {
       );
     }
 
-    let parent = t.offsetParent;
-    let tOffsetTop = t.offsetTop;
-    let cOffsetTop = 0;
+    // The offsetParent of an element, according to MDN, is its nearest positioned
+    // (an element whose position is anything other than static) ancestor. The offsetTop
+    // of an element is taken with respect to its offsetParent which may not neccessarily
+    // be its parentElement except the parent itself is positioned.
 
-    while (parent != c && parent !== document) {
-      tOffsetTop += parent.offsetTop;
-      cOffsetTop += parent.offsetTop;
-      parent = parent.offsetParent;
+    // So if containerElement is positioned, then it must be an offsetParent somewhere
+    // If it happens that targetElement is a descendant of the containerElement, and there
+    // is not intermediate positioned element between the two of them, i.e.
+    // targetElement"s offsetParent is the same as the containerElement, then the
+    // distance between the two will be the offsetTop of the targetElement.
+    // If, on the other hand, there are intermediate positioned elements between the
+    // two entities, the distance between the targetElement and the containerElement
+    // will be the accumulation of the offsetTop of the element and that of its
+    // subsequent offsetParent until the containerElement is reached, since it
+    // will also be an offsetParent at some point due to the fact that it is positioned.
+
+    // If the containerElement is not positioned, then it can"t be an offsetParent,
+    // which means that the offsetTop of the targetElement would not be with respect to it.
+    // However, if the two of them happen to have the same offsetParent, then
+    // the distance between them will be the difference between their offsetTop
+    // since they are both taken with respect to the same entity.
+    // The last resort would be to accumulate their offsetTop until a common
+    // offsetParent is reached (usually the document) and taking the difference
+    // between the accumulated offsetTops
+
+    if (isPositioned(c)) {
+      if (t.offsetParent !== c) {
+        const isContainerElementOrDocument = (e) => e === c || e === document;
+        const { offsetTop, offsetParent } = getElementOffsetInfoUntil(
+          t,
+          isContainerElementOrDocument
+        );
+
+        if (offsetParent !== c) {
+          throw new Error(
+            "Seems containerElement is not an ancestor of the Element"
+          );
+        }
+
+        return offsetTop;
+      }
+
+      return t.offsetTop;
     }
 
-    return getComputedStyle(c).position !== "static"
-      ? tOffsetTop
-      : tOffsetTop - cOffsetTop;
+    if (t.offsetParent === c.offsetParent) {
+      return t.offsetTop - c.offsetTop;
+    }
+
+    const isDocument = (e) => e === document;
+    return (
+      getElementOffsetInfoUntil(t, isDocument).offsetTop -
+      getElementOffsetInfoUntil(c, isDocument).offsetTop
+    );
   }
 };
+
 export default {
   updateHash,
   getHash,

--- a/modules/mixins/utils.js
+++ b/modules/mixins/utils.js
@@ -27,11 +27,25 @@ const scrollOffset = (c, t, horizontal) => {
       ? t.offsetLeft
       : t.offsetLeft - c.offsetLeft;
   } else {
-    return c === document
-      ? t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset)
-      : getComputedStyle(c).position !== "static"
-      ? t.offsetTop
-      : t.offsetTop - c.offsetTop;
+    if (c === document) {
+      return (
+        t.getBoundingClientRect().top + (window.scrollY || window.pageYOffset)
+      );
+    }
+
+    let parent = t.offsetParent;
+    let tOffsetTop = t.offsetTop;
+    let cOffsetTop = 0;
+
+    while (parent != c && parent !== document) {
+      tOffsetTop += parent.offsetTop;
+      cOffsetTop += parent.offsetTop;
+      parent = parent.offsetParent;
+    }
+
+    return getComputedStyle(c).position !== "static"
+      ? tOffsetTop
+      : tOffsetTop - cOffsetTop;
   }
 };
 export default {


### PR DESCRIPTION
In certain instances where an Element is not a direct descendant of the containerElement, it's offsetTop would be with respect to its parent not the containerElement. A use-case is as follows: 

```html
<div id="scrollable"> <!-- a scrollable entity-->
    <div>...</div><!--a very long entity-->
    <div id="container-1"> <!--not a scrollable entity-->
        <Element name="element-1">...</Element>
        <Element name="element-2">...</Element>
    </div>
    <div id="container-2"> <!--not a scrollable entity-->
        <Element name="element-3">...</Element>
        <Element name="element-4">...</Element>
    </div>
</div>
```

Invoking
```javascript
    scroller.scrollTo("element-x", {
       ...,
       containerId: "scrollable"
    });
```
would probably scroll back to the top (as was in my case) since element-x's offsetTop would be with respect to container-y (it's parent) and not "#scrollable". Setting containerId (in scrollTo) to the corresponding container of element-x wasn't working either, since what is being updated inside animateScroll.js is containerElement.scrollTop and since the corresponding containerElement isn't a scrollable entity, so no scrolling occurred. 

Accumulating the offsetTop of the targetElement and that of its offsetParent until either the current offsetParent is the same as the containerElement ("#scrollable") or document would give the actual offsetTop of the Element. 

Found something similar here: 6c02a597e20a32310c5bdd38a6b7e32695950e40 #403, seems it was removed

