### PR TITLE
Feature/add spy throttle amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ React.render(
 
 > horizontal - whether to scroll vertically (`false`) or horizontally (`true`) - default: `false`
 
+> spyThrottle - time of the spy throttle - can be a number
+
 ```js
 <Link activeClass="active"
       to="target"
@@ -201,6 +203,7 @@ React.render(
       onSetActive={this.handleSetActive}
       onSetInactive={this.handleSetInactive}
       ignoreCancelEvents={false}
+      spyThrottle={500}
 >
   Your name
 </Link>

--- a/modules/mixins/Helpers.js
+++ b/modules/mixins/Helpers.js
@@ -27,7 +27,8 @@ const protoTypes = {
   onSetActive: PropTypes.func,
   onSetInactive: PropTypes.func,
   ignoreCancelEvents: PropTypes.bool,
-  hashSpy: PropTypes.bool
+  hashSpy: PropTypes.bool,
+  spyThrottle: PropTypes.number
 };
 
 const Helpers = {
@@ -166,7 +167,7 @@ const Helpers = {
           let scrollSpyContainer = this.getScrollSpyContainer();
 
           if (!scrollSpy.isMounted(scrollSpyContainer)) {
-            scrollSpy.mount(scrollSpyContainer);
+            scrollSpy.mount(scrollSpyContainer, this.props.spyThrottle);
           }
 
           if (this.props.hashSpy) {

--- a/modules/mixins/scroll-link.js
+++ b/modules/mixins/scroll-link.js
@@ -23,7 +23,8 @@ const protoTypes = {
   onSetInactive: PropTypes.func,
   ignoreCancelEvents: PropTypes.bool,
   hashSpy: PropTypes.bool,
-  saveHashHistory: PropTypes.bool
+  saveHashHistory: PropTypes.bool,
+  spyThrottle: PropTypes.number
 };
 
 export default (Component, customScroller) => {
@@ -176,7 +177,7 @@ export default (Component, customScroller) => {
         let scrollSpyContainer = this.getScrollSpyContainer();
 
         if (!scrollSpy.isMounted(scrollSpyContainer)) {
-          scrollSpy.mount(scrollSpyContainer);
+          scrollSpy.mount(scrollSpyContainer, this.props.spyThrottle);
         }
 
         if (this.props.hashSpy) {

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -1,8 +1,8 @@
 import throttle from "lodash.throttle";
 import { addPassiveEventListener } from './passive-event-listeners';
 
-// The eventHandler will execute at a rate of 15fps
-const eventThrottler = (eventHandler)  => throttle(eventHandler, 66);
+// The eventHandler will execute at a rate of 15fps by default
+const eventThrottler = (eventHandler, throttleAmount = 66)  => throttle(eventHandler, throttleAmount);
 
 const scrollSpy = {
 
@@ -10,11 +10,11 @@ const scrollSpy = {
   spySetState: [],
   scrollSpyContainers: [],
 
-  mount(scrollSpyContainer) {
+  mount(scrollSpyContainer, throttle) {
     if (scrollSpyContainer) {
       const eventHandler = eventThrottler((event) => {
         scrollSpy.scrollHandler(scrollSpyContainer);
-      });
+      }, throttle);
       scrollSpy.scrollSpyContainers.push(scrollSpyContainer);
       addPassiveEventListener(scrollSpyContainer, 'scroll', eventHandler);
     }


### PR DESCRIPTION
iOS browsers throw an error `SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds` in situation when there are too many links with hashSpy on page.

To reproduce issue:
1. Setup a page with many `hashSpy: true` Links.
2. (This step needs mobile iOS debugger or some other way to log this error) Connect debugger with mobile device and start scrolling up and down.

This PR adds `spyThrottle` property which enables us to control how frequently is history.replaceState() happening

Tested on
iOS version: 14.4.2(though we've been seeing it on other 14.x)