### PR TITLE
Fix position check for tests using jsdom

### DIFF
--- a/modules/mixins/utils.js
+++ b/modules/mixins/utils.js
@@ -19,8 +19,10 @@ const filterElementInContainer = (container) => (element) =>
     ? container != element && container.contains(element)
     : !!(container.compareDocumentPosition(element) & 16);
 
-const isPositioned = (element) =>
-  getComputedStyle(element).position !== "static";
+const isPositioned = (element) => {
+  const position = getComputedStyle(element).position;
+  return position && position !== "static";
+};
 
 const getElementOffsetInfoUntil = (element, predicate) => {
   let offsetTop = element.offsetTop;


### PR DESCRIPTION
The position is an empty string there, which I think should count as equivalent to static. Currently this change caused my tests to break.