### PR TITLE
fix: prevent unexpected spy callback removal on multiple unmount calls

### DIFF
--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -74,7 +74,7 @@ const scrollSpy = {
   unmount(stateHandler, spyHandler) {
     scrollSpy.scrollSpyContainers.forEach(c => c.spyCallbacks && c.spyCallbacks.length && c.spyCallbacks.indexOf(spyHandler) > -1 && c.spyCallbacks.splice(c.spyCallbacks.indexOf(spyHandler), 1))
 
-    if(scrollSpy.spySetState && scrollSpy.spySetState.length) {
+    if(scrollSpy.spySetState && scrollSpy.spySetState.length && scrollSpy.spySetState.indexOf(stateHandler) > -1) {
       scrollSpy.spySetState.splice(scrollSpy.spySetState.indexOf(stateHandler), 1);
     }
 

--- a/modules/mixins/scroll-spy.js
+++ b/modules/mixins/scroll-spy.js
@@ -72,7 +72,7 @@ const scrollSpy = {
   },
 
   unmount(stateHandler, spyHandler) {
-    scrollSpy.scrollSpyContainers.forEach(c => c.spyCallbacks && c.spyCallbacks.length && c.spyCallbacks.splice(c.spyCallbacks.indexOf(spyHandler), 1))
+    scrollSpy.scrollSpyContainers.forEach(c => c.spyCallbacks && c.spyCallbacks.length && c.spyCallbacks.indexOf(spyHandler) > -1 && c.spyCallbacks.splice(c.spyCallbacks.indexOf(spyHandler), 1))
 
     if(scrollSpy.spySetState && scrollSpy.spySetState.length) {
       scrollSpy.spySetState.splice(scrollSpy.spySetState.indexOf(stateHandler), 1);


### PR DESCRIPTION
**Problem**:
Multiple scrollSpy.unmount() calls may occur on same Link due to component tree rebuild. Subsequent calls will try to remove already non-existing spyHandler. In this case .indexOf(spyHandler) will return -1 and .splice(-1, 1) will cause unwanted removal of last spyHandler in list.
Same with setState handlers.

**Solution**
Add extra check to make sure spyHandler and setState are in lists
