### PR TITLE
Preventing duplicate event listener registrations

### DIFF
--- a/modules/mixins/animate-scroll.js
+++ b/modules/mixins/animate-scroll.js
@@ -171,9 +171,10 @@ const animateTopScroll = (scrollOffset, options, to, target) => {
 
   window.clearTimeout(options.data.delayTimeout);
 
-  cancelEvents.subscribe(() => {
+  const setCancel = () => {
     options.data.cancel = true;
-  });
+  };
+  cancelEvents.subscribe(setCancel);
 
   setContainer(options);
 

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -4,11 +4,15 @@
  * to wait for the listener to return.
  */
 export const addPassiveEventListener = (target, eventName, listener) => {
-  if (!listener.name) console.warn('Listener must be a named function.');
+  let listenerName = listener.name;
+  if (!listenerName) {
+    listenerName = eventName + new Date().getTime();
+    console.warn('Listener must be a named function.');
+  }
 
   if (!attachedListeners.has(eventName)) attachedListeners.set(eventName, new Set());
   const listeners = attachedListeners.get(eventName);
-  if (listeners.has(listener.name)) return;
+  if (listeners.has(listenerName)) return;
 
   const supportsPassiveOption = (() => {
     let supportsPassiveOption = false;
@@ -23,7 +27,7 @@ export const addPassiveEventListener = (target, eventName, listener) => {
     return supportsPassiveOption;
   })();
   target.addEventListener(eventName, listener, supportsPassiveOption ? { passive: true } : false);
-  listeners.add(listener.name);
+  listeners.add(listenerName);
 };
 
 export const removePassiveEventListener = (target, eventName, listener) => {

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -4,9 +4,9 @@
  * to wait for the listener to return.
  */
 export const addPassiveEventListener = (target, eventName, listener) => {
-  if (!attachedListeners.has(eventName)) {
-    attachedListeners.set(eventName, new Set());
-  }
+  if (!listener.name) throw new Error('Listener must be a named function.');
+
+  if (!attachedListeners.has(eventName)) attachedListeners.set(eventName, new Set());
   const listeners = attachedListeners.get(eventName);
   if (listeners.has(listener.name)) return;
 

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -6,7 +6,7 @@
 export const addPassiveEventListener = (target, eventName, listener) => {
   let listenerName = listener.name;
   if (!listenerName) {
-    listenerName = eventName + new Date().getTime();
+    listenerName = eventName;
     console.warn('Listener must be a named function.');
   }
 

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -4,7 +4,7 @@
  * to wait for the listener to return.
  */
 export const addPassiveEventListener = (target, eventName, listener) => {
-  if (!listener.name) throw new Error('Listener must be a named function.');
+  if (!listener.name) console.warn('Listener must be a named function.');
 
   if (!attachedListeners.has(eventName)) attachedListeners.set(eventName, new Set());
   const listeners = attachedListeners.get(eventName);

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -4,6 +4,12 @@
  * to wait for the listener to return.
  */
 export const addPassiveEventListener = (target, eventName, listener) => {
+  if (!attachedListeners.has(eventName)) {
+    attachedListeners.set(eventName, new Set());
+  }
+  const listeners = attachedListeners.get(eventName);
+  if (listeners.has(listener.name)) return;
+
   const supportsPassiveOption = (() => {
     let supportsPassiveOption = false;
     try {
@@ -17,9 +23,11 @@ export const addPassiveEventListener = (target, eventName, listener) => {
     return supportsPassiveOption;
   })();
   target.addEventListener(eventName, listener, supportsPassiveOption ? { passive: true } : false);
+  listeners.add(listener.name);
 };
 
 export const removePassiveEventListener = (target, eventName, listener) => {
   target.removeEventListener(eventName, listener);
 }
 
+const attachedListeners = new Map();

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -28,6 +28,7 @@ export const addPassiveEventListener = (target, eventName, listener) => {
 
 export const removePassiveEventListener = (target, eventName, listener) => {
   target.removeEventListener(eventName, listener);
+  attachedListeners.get(eventName).delete(listener.name);
 }
 
 const attachedListeners = new Map();

--- a/modules/mixins/passive-event-listeners.js
+++ b/modules/mixins/passive-event-listeners.js
@@ -32,7 +32,7 @@ export const addPassiveEventListener = (target, eventName, listener) => {
 
 export const removePassiveEventListener = (target, eventName, listener) => {
   target.removeEventListener(eventName, listener);
-  attachedListeners.get(eventName).delete(listener.name);
+  attachedListeners.get(eventName).delete(listener.name || eventName);
 }
 
 const attachedListeners = new Map();


### PR DESCRIPTION
I encountered an issue where event listeners were being registered multiple times.

I discovered that when calling scrollTo-related functions in the `animate-scroll` module, event listeners were being registered through the `subscribe` method. 

There was no logic to remove registered events or check for duplicates, resulting in event listeners being registered multiple times. 

I have thought of the simplest solution: preventing duplicate registrations by using the name of the listener function passed as a parameter to the `addPassiveEventListener` function as a key. 

It is important to note that you should pass a named function with a **unique name as the listener parameter**, rather than an anonymous function.

Fix for #451

<hr/>

- As-is
<img width="500" alt="before" src="https://github.com/fisshy/react-scroll/assets/58316983/2ccadbff-ff00-44e1-bebf-b6689d122f57">

<br/>
<br/>

- To-be
<img width="500" alt="after" src="https://github.com/fisshy/react-scroll/assets/58316983/52fdaee1-acac-4ba6-99af-d7283b6a0802">



