### PR TITLE
change mouseWheel event in cancel events

### DIFF
--- a/modules/mixins/cancel-events.js
+++ b/modules/mixins/cancel-events.js
@@ -1,5 +1,5 @@
 import { addPassiveEventListener, removePassiveEventListener } from './passive-event-listeners';
-const events = ['mousedown', 'mousewheel', 'touchmove', 'keydown']
+const events = ['mousedown', 'wheel', 'touchmove', 'keydown']
 
 export default {
   subscribe : (cancelEvent) => (typeof document !== 'undefined') && events.forEach(event => addPassiveEventListener(document, event, cancelEvent)),


### PR DESCRIPTION
`mouseWheel` event is deprecated and is not compatible with Firefox. Thus, on Firefox when scrolling is happening and user wants to stop the scrolling with mouse wheel, scrolling doesn't cancel. All other events seems to be working normally.

https://developer.mozilla.org/en-US/docs/Web/API/Element/mousewheel_event