### PR TITLE
escape tags in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > 1.9.0
 
-- Now uses <button> instead of <input /> [PR](https://github.com/fisshy/react-scroll/pull/559)
+- Now uses `<button>` instead of `<input />` [PR](https://github.com/fisshy/react-scroll/pull/559)
 
 > 1.8.9
 


### PR DESCRIPTION
The HTML tags in the changelog need to be escaped

![image](https://github.com/fisshy/react-scroll/assets/19188/46c7d4e0-46bc-4b9f-b30a-c56ad8747ea9)
